### PR TITLE
Always call after_process

### DIFF
--- a/saq/__init__.py
+++ b/saq/__init__.py
@@ -3,4 +3,4 @@ from saq.queue import Queue
 from saq.worker import Worker
 
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"

--- a/saq/worker.py
+++ b/saq/worker.py
@@ -163,10 +163,11 @@ class Worker:
             if self.timers["monitor"]:
                 monitor = asyncio.create_task(self.monitor(task, job_id))
 
-            result = await asyncio.wait_for(task, job.timeout)
-
-            if self.after_process:
-                await self.after_process(context)
+            try:
+                result = await asyncio.wait_for(task, job.timeout)
+            finally:
+                if self.after_process:
+                    await self.after_process(context)
 
             await job.finish(Status.COMPLETE, result=result)
         except asyncio.CancelledError:

--- a/saq/worker.py
+++ b/saq/worker.py
@@ -179,7 +179,11 @@ class Worker:
                 else:
                     await job.retry(error)
         finally:
-            if self.after_process and job.status in (Status.FAILED, Status.COMPLETE):
+            if (
+                self.after_process
+                and job
+                and job.status in (Status.FAILED, Status.COMPLETE)
+            ):
                 await self.after_process(context)
 
             if monitor and not monitor.done():

--- a/saq/worker.py
+++ b/saq/worker.py
@@ -163,11 +163,7 @@ class Worker:
             if self.timers["monitor"]:
                 monitor = asyncio.create_task(self.monitor(task, job_id))
 
-            try:
-                result = await asyncio.wait_for(task, job.timeout)
-            finally:
-                if self.after_process:
-                    await self.after_process(context)
+            result = await self.wait_for_task(context, task, job.timeout)
 
             await job.finish(Status.COMPLETE, result=result)
         except asyncio.CancelledError:
@@ -195,6 +191,13 @@ class Worker:
             new_task = asyncio.create_task(self.process())
             self.tasks.add(new_task)
             new_task.add_done_callback(self._process)
+
+    async def wait_for_task(self, context, task, timeout):
+        try:
+            return await asyncio.wait_for(task, timeout)
+        finally:
+            if self.after_process:
+                await self.after_process(context)
 
 
 def start(settings, web=False, port=8080):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -170,7 +170,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         await self.queue.enqueue("error")
         await worker.process()
         self.assertEqual(x["before"], 2)
-        self.assertEqual(x["after"], 1)
+        self.assertEqual(x["after"], 2)
 
     @mock.patch("saq.utils.time")
     async def test_schedule(self, mock_time):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -172,6 +172,12 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(x["before"], 2)
         self.assertEqual(x["after"], 2)
 
+        task = asyncio.create_task(worker.process())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        self.assertEqual(x["before"], 2)
+        self.assertEqual(x["after"], 2)
+
     @mock.patch("saq.utils.time")
     async def test_schedule(self, mock_time):
         mock_time.time.return_value = 1


### PR DESCRIPTION
Call after_process so any clean up can still occur even if the job raised an exception.