### PR TITLE
Fix lint errors for pylint 2.12.2 -> 2.13.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm
+.idea/

--- a/saq/queue.py
+++ b/saq/queue.py
@@ -119,13 +119,15 @@ class Queue:
                 else []
             )
 
-            queue_info.update({
-                "name": name,
-                "queued": queued,
-                "active": active,
-                "scheduled": incomplete - queued - active,
-                "jobs": jobs,
-            })
+            queue_info.update(
+                {
+                    "name": name,
+                    "queued": queued,
+                    "active": active,
+                    "scheduled": incomplete - queued - active,
+                    "jobs": jobs,
+                }
+            )
 
         return queues
 

--- a/saq/queue.py
+++ b/saq/queue.py
@@ -93,7 +93,7 @@ class Queue:
                 stats = json.loads(stats.decode("UTF-8"))
                 queues[name]["workers"][worker] = stats
 
-        for name in queues:
+        for name, queue_info in queues.items():
             queue = Queue(self.redis, name=name)
             queued = await queue.count("queued")
             active = await queue.count("active")
@@ -119,14 +119,13 @@ class Queue:
                 else []
             )
 
-            queues[name] = {
+            queue_info.update({
                 "name": name,
                 "queued": queued,
                 "active": active,
                 "scheduled": incomplete - queued - active,
                 "jobs": jobs,
-                **queues[name],
-            }
+            })
 
         return queues
 


### PR DESCRIPTION
This is failing on other PRs before a new version of pylint has been released.

We can consider pinning the pylint version. But this wasn't that painful 🤷 

@tobymao 