### PR TITLE
Handle alternative deserialization in UI

### DIFF
--- a/saq/monitor.py
+++ b/saq/monitor.py
@@ -1,0 +1,123 @@
+import json
+
+from saq import Queue, Job
+from saq.queue import STATS_KEY
+from saq.utils import now
+
+
+class ImpersonatorQueue(Queue):
+    """
+    Queue that can read jobs from other queues.
+
+    This little hack is intended solely for monitoring purposes.
+    """
+
+    def impersonate(self, name):
+        return impersonate(queue=self, new_name=name)
+
+    def _init_job(self, job_dict):
+        queue_name = job_dict.pop("queue")
+        queue = self.impersonate(name=queue_name)
+        return Job(**job_dict, queue=queue)
+
+
+def impersonate(queue, new_name="impersonator"):
+    return ImpersonatorQueue(
+        redis=queue.redis,
+        name=new_name,
+        dump=queue.dump,
+        load=queue.load,
+    )
+
+
+def _transform_in_place(dictionary, key, transform):
+    if key in dictionary:
+        dictionary[key] = transform(dictionary[key])
+
+
+def json_safe_job(job):
+    job_dict = job.to_dict()
+    _transform_in_place(job_dict, "kwargs", repr)
+    _transform_in_place(job_dict, "result", repr)
+    return job_dict
+
+
+class Monitor:
+    """
+    Monitor to inspect all active queues.
+
+    queue: queue from which to steal a connection to redis
+    """
+
+    @classmethod
+    def from_url(cls, url):
+        """Create a queue with a redis url a name."""
+        return cls(ImpersonatorQueue.from_url(url))
+
+    def __init__(self, queue):
+        self.redis = queue.redis
+        self.queue = impersonate(queue=queue)
+
+    async def info(self, queue=None, jobs=False, offset=0, limit=10):
+        # pylint: disable=too-many-locals
+        queues = {}
+        keys = []
+
+        for key in await self.redis.zrangebyscore(STATS_KEY, now(), "inf"):
+            key = key.decode("utf-8")
+            _, name, _, worker = key.split(":")
+            queues[name] = {"workers": {}}
+            keys.append((name, worker))
+
+        worker_stats = await self.redis.mget(
+            f"saq:{name}:stats:{worker}" for name, worker in keys
+        )
+
+        for (name, worker), stats in zip(keys, worker_stats):
+            if stats:
+                stats = json.loads(stats.decode("UTF-8"))
+                queues[name]["workers"][worker] = stats
+
+        for name, queue_info in queues.items():
+            queue = self.queue.impersonate(name=name)
+            queued = await queue.count("queued")
+            active = await queue.count("active")
+            incomplete = await queue.count("incomplete")
+
+            jobs = (
+                [
+                    json_safe_job(queue.deserialize(job_bytes))
+                    for job_bytes in await self.redis.mget(
+                        (
+                            await self.redis.lrange(
+                                queue.namespace("active"), offset, limit - 1
+                            )
+                        )
+                        + (
+                            await self.redis.lrange(
+                                queue.namespace("queued"), offset, limit - 1
+                            )
+                        )
+                    )
+                ]
+                if jobs
+                else []
+            )
+
+            queue_info.update(
+                {
+                    "name": name,
+                    "queued": queued,
+                    "active": active,
+                    "scheduled": incomplete - queued - active,
+                    "jobs": jobs,
+                }
+            )
+
+        return queues
+
+    async def job(self, job_key):
+        return await self.queue.job(Job.id_from_key(job_key))
+
+    async def disconnect(self):
+        await self.queue.disconnect()

--- a/saq/static/app.js
+++ b/saq/static/app.js
@@ -116,7 +116,7 @@ const job_headers = () => [
 
 const job_columns = job => [
   h("td", job.function),
-  h("td", JSON.stringify(job.kwargs)),
+  h("td", job.kwargs),
   h("td", format_time(job.queued)),
   h("td", format_time(job.started)),
   h("td", format_time(job.completed)),
@@ -210,14 +210,14 @@ const job_view = function(data, job_key) {
       ])),
       h("tbody", h("tr", [
         ...job_columns(job),
-        h("td", link({props: {href: "/queue/" + job.queue}}, job.queue)),
+        h("td", link({props: {href: "/queues/" + job.queue}}, job.queue)),
         h("td", h("progress", {props: {value: job.progress || 0, max: 1.0}})),
         h("td", job.attempts),
       ])),
     ])),
     h("details", {props: {open: true}}, [
       h("summary", "Result"),
-      h("p", JSON.stringify(job.result)),
+      h("p", job.result),
     ]),
     h("details", {props: {open: true}}, [
       h("summary", "Error"),

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,52 @@
+import unittest
+
+from saq import Worker
+from saq.monitor import Monitor
+from tests.helpers import create_queue, cleanup_queue
+
+
+async def echo(_ctx, *, a):
+    return a
+
+
+functions = [echo]
+
+
+class TestMonitor(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.queue1 = create_queue(name="queue1")
+        self.queue2 = create_queue(name="queue2")
+        self.worker1 = Worker(self.queue1, functions=functions)
+        self.worker2 = Worker(self.queue2, functions=functions)
+        self.monitor = Monitor(self.queue1)
+
+    async def asyncTearDown(self):
+        await cleanup_queue(self.queue1)
+        await cleanup_queue(self.queue2)
+
+    async def test_info(self):
+        await self.queue1.enqueue("echo", a=1)
+        await self.queue1.enqueue("echo", a=2)
+        await self.queue2.enqueue("echo", a=3)
+        await self.worker1.process()
+        await self.worker2.process()
+        info = await self.monitor.info(jobs=True)
+        self.assertEqual(info, {})
+        await self.queue1.stats()
+        await self.queue2.stats()
+        info = await self.monitor.info(jobs=True)
+        self.assertIn("queue1", info)
+        self.assertIn("queue2", info)
+        self.assertEqual(info["queue1"]["queued"], 1)
+        self.assertEqual(len(info["queue1"]["jobs"]), 1)
+        self.assertEqual(info["queue1"]["jobs"][0]["kwargs"], repr({"a": 1}))
+        self.assertEqual(info["queue2"]["queued"], 0)
+        self.assertEqual(len(info["queue2"]["jobs"]), 0)
+
+    async def test_job(self):
+        job = await self.queue1.enqueue("echo", a=1)
+        await self.worker1.process()
+        monitor_job = await self.monitor.job(job.key)
+        self.assertEqual(monitor_job.queue.name, "queue1")
+        self.assertEqual(monitor_job.kwargs, {"a": 1})
+        self.assertEqual(monitor_job.result, 1)


### PR DESCRIPTION
This fixes a couple bugs:

**Alternative job serialization in the UI**
The UI would always attempt to use JSON serialization for jobs. 
This would break the UI if configuring a different dump/load function (e.g. pickle).

Now, the UI uses the same dump/load function that the worker/queue are configured with. Note - this means the UI will break if attempting to view jobs from _other_ queues that might have a different dump/load function. 

I think it's possible to solve the above problem by having two different serialization steps. Something like this:
```
Job --marshal--> JobMessage --serialize--> bytes
```
Where:
- `Job` is a user-friendly object exposed in the public API
- `marshal` are the user provided dump/load functions, but now they only apply to kwargs and result
- `JobMessage` is a simpler object that can be handled without unmarshaling. We could implement UI monitoring/control based on this object.
- `serialize` would be json.loads. And maybe something like msgpack in the future.
- `bytes` would be what we actually store in Redis

But the coupling of Queue and Job is pretty strong right now, and it gets pretty messy to untangle. So I think we should punt on all that for now.

**Viewing a job's queue in the UI**
Queue's were always binding themselves to jobs they read.
That ultimately meant jobs in the UI would always show as being part of whatever queue the web server was running off of.

I've added this `ImpersonatorQueue` to handle this.

Kind ugly.. but a pure solution involves the same proposal above.

@tobymao 