### PR TITLE
Support synchronous job functions

### DIFF
--- a/saq/worker.py
+++ b/saq/worker.py
@@ -3,7 +3,6 @@ import logging
 import signal
 import traceback
 import os
-from functools import partial, wraps
 
 from croniter import croniter
 
@@ -240,11 +239,10 @@ def ensure_coroutine_function(func):
     if asyncio.iscoroutinefunction(func):
         return func
 
-    @wraps(func)
     async def wrapped(*args, **kwargs):
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(
-            executor=None, func=partial(func, *args, **kwargs)
+            executor=None, func=lambda: func(*args, **kwargs)
         )
 
     return wrapped

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -28,7 +28,11 @@ async def error(_ctx):
     raise ValueError("oops")
 
 
-functions = [noop, sleeper, error]
+def sync_echo(_ctx, *, a):
+    return a
+
+
+functions = [noop, sleeper, error, sync_echo]
 
 
 class TestWorker(unittest.IsolatedAsyncioTestCase):
@@ -264,3 +268,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(await self.queue.count("queued"), 1)
         self.assertEqual(await self.queue.count("incomplete"), 1)
         self.assertEqual(await self.queue.count("active"), 0)
+
+    async def test_sync_function(self):
+        asyncio.create_task(self.worker.start())
+        assert await self.queue.apply("sync_echo", a=1) == 1


### PR DESCRIPTION
This lets users define synchronous job functions.

This is essentially the same thing that FastAPI does: https://github.com/tiangolo/fastapi/blob/master/fastapi/routing.py#L152

This isn't strictly required, as it's easy to workaround for users. But IMO, this is a nice framework convenience.

@tobymao 
