### PR TITLE
Monitor multiple queues in the Web UI

### DIFF
--- a/examples/map.py
+++ b/examples/map.py
@@ -20,6 +20,7 @@ async def sum_of_squares(ctx, *, n):
 
 
 settings = {
+    "queue": queue,
     "functions": [square, sum_of_squares],
     "concurrency": 100,
 }

--- a/saq/__main__.py
+++ b/saq/__main__.py
@@ -26,7 +26,14 @@ def main():
     parser.add_argument(
         "--web",
         action="store_true",
-        help="Start web app",
+        help="Start web app. "
+        "By default, this only monitors the current worker's queue. To monitor multiple queues, see '--web-settings'",
+    )
+    parser.add_argument(
+        "--additional-web-settings",
+        "-a",
+        action="append",
+        help="Additional worker settings to monitor in the web app",
     )
     parser.add_argument(
         "--port",
@@ -63,7 +70,12 @@ def main():
                 p = multiprocessing.Process(target=start, args=(settings,))
                 p.start()
 
-        start(settings, web=args.web, port=args.port)
+        start(
+            settings,
+            web=args.web,
+            additional_web_settings=args.additional_web_settings,
+            port=args.port,
+        )
 
 
 if __name__ == "__main__":

--- a/saq/static/app.js
+++ b/saq/static/app.js
@@ -116,7 +116,7 @@ const job_headers = () => [
 
 const job_columns = job => [
   h("td", job.function),
-  h("td", JSON.stringify(job.kwargs)),
+  h("td", job.kwargs),
   h("td", format_time(job.queued)),
   h("td", format_time(job.started)),
   h("td", format_time(job.completed)),
@@ -171,7 +171,7 @@ const queue_view = function(data, queue_name) {
       h("thead", h("tr", [h("th", "Key"), ...job_headers()])),
       h("tbody", queue.jobs.map(job =>
         h("tr", [
-          link({props: {href: "/jobs/" + job.key}}, h("td", job.key)),
+          link({props: {href: "/queues/" + queue_name + "/jobs/" + job.key}}, h("td", job.key)),
           ...job_columns(job),
         ])
       )),
@@ -179,18 +179,18 @@ const queue_view = function(data, queue_name) {
   ])
 }
 
-const job_view = function(data, job_key) {
+const job_view = function(data, queue_name, job_key) {
   const job = data.job
   const buttons = [button(
     "Retry",
-    event => post("/jobs/" + job_key + "/retry"),
+    event => post("/queues/" + queue_name + "/jobs/" + job_key + "/retry"),
     {style: {marginRight: "1rem"}},
   )]
 
   if (!job.completed) {
     buttons.push(button(
       "Abort",
-      event => post("/jobs/" + job_key + "/abort"),
+      event => post("/queues/" + queue_name + "/jobs/" + job_key + "/abort"),
       {style: {borderColor: "#d81b60", backgroundColor: "#d81b60"}},
     ))
   }
@@ -210,14 +210,14 @@ const job_view = function(data, job_key) {
       ])),
       h("tbody", h("tr", [
         ...job_columns(job),
-        h("td", link({props: {href: "/queue/" + job.queue}}, job.queue)),
+        h("td", link({props: {href: "/queues/" + job.queue}}, job.queue)),
         h("td", h("progress", {props: {value: job.progress || 0, max: 1.0}})),
         h("td", job.attempts),
       ])),
     ])),
     h("details", {props: {open: true}}, [
       h("summary", "Result"),
-      h("p", JSON.stringify(job.result)),
+      h("p", job.result),
     ]),
     h("details", {props: {open: true}}, [
       h("summary", "Error"),
@@ -236,7 +236,7 @@ const error_view = function(error) {
 let routes = {
   '/': {view: home_view, data: "/queues"},
   '/queues/:queue_id': {view: queue_view},
-  '/jobs/:job_id': {view: job_view}
+  '/queues/:queue_id/jobs/:job_id': {view: job_view}
 }
 
 routes = Object.keys(routes)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,67 @@
+import logging
+from aiohttp.test_utils import AioHTTPTestCase
+
+from saq.job import Status
+from saq.worker import Worker
+from saq.web import create_app
+from tests.helpers import create_queue, cleanup_queue
+
+
+logging.getLogger().setLevel(logging.CRITICAL)
+
+
+async def echo(_ctx, *, a):
+    return a
+
+
+functions = [echo]
+
+
+class TestWorker(AioHTTPTestCase):
+    async def get_application(self):
+        self.queue1 = create_queue(name="queue1")
+        self.queue2 = create_queue(name="queue2")
+        self.worker = Worker(self.queue1, functions=functions)
+        return create_app(queues=[self.queue1, self.queue2])
+
+    async def asyncTearDown(self):
+        await cleanup_queue(self.queue1)
+        await cleanup_queue(self.queue2)
+
+    async def test_queues(self):
+        async with self.client.get("/api/queues") as resp:
+            self.assertEqual(resp.status, 200)
+            json = await resp.json()
+            self.assertEqual(
+                set(q["name"] for q in json["queues"]), {"queue1", "queue2"}
+            )
+
+        async with self.client.get(f"/api/queues/{self.queue1.name}") as resp:
+            self.assertEqual(resp.status, 200)
+            json = await resp.json()
+            self.assertEqual(json["queue"]["name"], "queue1")
+
+    async def test_jobs(self):
+        job = await self.queue1.enqueue("echo", a=1)
+        url = f"/api/queues/{self.queue1.name}/jobs/{job.key}"
+        await self.worker.process()
+        await job.refresh()
+        self.assertEqual(job.status, Status.COMPLETE)
+
+        async with self.client.get(url) as resp:
+            self.assertEqual(resp.status, 200)
+            json = await resp.json()
+            self.assertEqual(json["job"]["kwargs"], repr({"a": 1}))
+            self.assertEqual(json["job"]["result"], repr(1))
+
+        async with self.client.post(f"{url}/retry") as resp:
+            self.assertEqual(resp.status, 200)
+
+        await job.refresh()
+        self.assertEqual(job.status, Status.QUEUED)
+
+        async with self.client.post(f"{url}/abort") as resp:
+            self.assertEqual(resp.status, 200)
+
+        await job.refresh()
+        self.assertEqual(job.status, Status.ABORTED)


### PR DESCRIPTION
This is the result of our discussion on https://github.com/tobymao/saq/pull/13

Before this PR, a web UI instance monitors all queues in the same Redis database. This had some fundamental issues.

This change makes it so a web UI instance only monitors the queue for the worker it's attached to.

If users want to monitor multiple queues in the web UI, they can append `--additional-web-settings` parameters to the `saq` command.

@tobymao 