### PR TITLE
Better support for context propagation

### DIFF
--- a/examples/propagation.py
+++ b/examples/propagation.py
@@ -1,0 +1,66 @@
+import asyncio
+import contextvars
+import logging
+
+from saq import Queue
+from saq.utils import uuid1
+
+logger = logging.getLogger(__name__)
+
+correlation_id_ctx = contextvars.ContextVar("correlation_id_ctx")
+
+queue = Queue.from_url("redis://localhost")
+
+
+async def recurse(ctx, *, n):
+    logger.info(n)
+    if n == 0:
+        return
+    await queue.apply("recurse", n=n - 1)
+
+
+async def before_process(ctx):
+    correlation_id = ctx["job"].meta.get("correlation_id")
+    ctx["reset_token"] = correlation_id_ctx.set(correlation_id)
+
+
+async def after_process(ctx):
+    correlation_id_ctx.reset(ctx["reset_token"])
+
+
+async def before_enqueue(job):
+    job.meta["correlation_id"] = correlation_id_ctx.get(None) or uuid1()
+
+
+queue.register_before_enqueue(before_enqueue)
+
+settings = {
+    "queue": queue,
+    "functions": [recurse],
+    "concurrency": 100,
+    "before_process": before_process,
+    "after_process": after_process,
+}
+
+
+class LoggingContextFilter(logging.Filter):
+    def filter(self, record):
+        record.correlation_id = correlation_id_ctx.get(None)
+        return True
+
+
+handler = logging.StreamHandler()
+handler.addFilter(LoggingContextFilter())
+handler.setFormatter(logging.Formatter("%(correlation_id)s - %(message)s"))
+handler.setLevel(logging.INFO)
+root_logger = logging.getLogger()
+root_logger.setLevel(logging.INFO)
+root_logger.handlers = [handler]
+
+
+async def enqueue():
+    await queue.apply("recurse", n=3)
+
+
+if __name__ == "__main__":
+    asyncio.run(enqueue())

--- a/examples/propagation.py
+++ b/examples/propagation.py
@@ -19,17 +19,13 @@ async def recurse(ctx, *, n):
     await queue.apply("recurse", n=n - 1)
 
 
-async def before_process(ctx):
-    correlation_id = ctx["job"].meta.get("correlation_id")
-    ctx["reset_token"] = correlation_id_ctx.set(correlation_id)
-
-
-async def after_process(ctx):
-    correlation_id_ctx.reset(ctx["reset_token"])
-
-
 async def before_enqueue(job):
     job.meta["correlation_id"] = correlation_id_ctx.get(None) or uuid1()
+
+
+async def before_process(ctx):
+    correlation_id = ctx["job"].meta.get("correlation_id")
+    correlation_id_ctx.set(correlation_id)
 
 
 queue.register_before_enqueue(before_enqueue)
@@ -39,7 +35,6 @@ settings = {
     "functions": [recurse],
     "concurrency": 100,
     "before_process": before_process,
-    "after_process": after_process,
 }
 
 

--- a/saq/job.py
+++ b/saq/job.py
@@ -145,18 +145,11 @@ class Job:
     def to_dict(self):
         result = {}
         for field in dataclasses.fields(self):
-            value = getattr(self, field.name)
-
-            if field.name == "queue" and value:
+            key = field.name
+            value = getattr(self, key)
+            if key == "queue" and value:
                 value = value.name
-
-            default = field.default
-            if field.default_factory != dataclasses.MISSING:
-                default = field.default_factory()
-
-            if value != default:
-                result[field.name] = value
-
+            result[key] = value
         return result
 
     def duration(self, kind):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -83,3 +83,11 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         self.assertAlmostEqual(job.next_retry_delay(), 1.0)
         job = Job("f", retry_delay=1.0, retry_backoff=True, attempts=3)
         self.assertTrue(0 <= job.next_retry_delay() < 4)
+
+    async def test_meta(self):
+        self.assertNotIn("meta", Job("f").to_dict())
+        job = Job("f", meta={"a": 1})
+        self.assertEqual(job.to_dict()["meta"], {"a": 1})
+        job = Job("f")
+        job.meta["a"] = 1
+        self.assertEqual(job.to_dict()["meta"], {"a": 1})

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -83,11 +83,3 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         self.assertAlmostEqual(job.next_retry_delay(), 1.0)
         job = Job("f", retry_delay=1.0, retry_backoff=True, attempts=3)
         self.assertTrue(0 <= job.next_retry_delay() < 4)
-
-    async def test_meta(self):
-        self.assertNotIn("meta", Job("f").to_dict())
-        job = Job("f", meta={"a": 1})
-        self.assertEqual(job.to_dict()["meta"], {"a": 1})
-        job = Job("f")
-        job.meta["a"] = 1
-        self.assertEqual(job.to_dict()["meta"], {"a": 1})

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,14 +1,18 @@
 import asyncio
+import contextvars
 import logging
 import unittest
 from unittest import mock
 
 from saq.job import CronJob, Status
+from saq.utils import uuid1
 from saq.worker import Worker
 from tests.helpers import create_queue, cleanup_queue
 
 
 logging.getLogger().setLevel(logging.CRITICAL)
+
+ctx_var = contextvars.ContextVar("ctx_var")
 
 
 async def noop(_ctx):
@@ -28,11 +32,19 @@ async def error(_ctx):
     raise ValueError("oops")
 
 
-def sync_echo(_ctx, *, a):
-    return a
+def sync_echo_ctx(_ctx):
+    return ctx_var.get()
 
 
-functions = [noop, sleeper, error, sync_echo]
+async def recurse(ctx, *, n):
+    var = ctx_var.get()
+    result = [var]
+    if n > 0:
+        result += await ctx["queue"].apply("recurse", n=n - 1)
+    return result
+
+
+functions = [noop, sleeper, error, sync_echo_ctx, recurse]
 
 
 class TestWorker(unittest.IsolatedAsyncioTestCase):
@@ -270,5 +282,29 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(await self.queue.count("active"), 0)
 
     async def test_sync_function(self):
+        async def before_process(*_, **__):
+            ctx_var.set("123")
+
+        self.worker.before_process = before_process
         asyncio.create_task(self.worker.start())
-        assert await self.queue.apply("sync_echo", a=1) == 1
+        self.assertEqual(await self.queue.apply("sync_echo_ctx"), "123")
+
+    async def test_propagation(self):
+        async def before_process(ctx):
+            correlation_id = ctx["job"].meta.get("correlation_id")
+            ctx["reset_token"] = ctx_var.set(correlation_id)
+            ctx["queue"] = self.queue
+
+        async def after_process(ctx):
+            ctx_var.reset(ctx["reset_token"])
+
+        async def before_enqueue(job):
+            job.meta["correlation_id"] = ctx_var.get(None) or uuid1()
+
+        self.worker.before_process = before_process
+        self.worker.after_process = after_process
+        self.queue.register_before_enqueue(before_enqueue)
+        asyncio.create_task(self.worker.start())
+        correlation_ids = await self.queue.apply("recurse", n=2)
+        self.assertEqual(len(correlation_ids), 3)
+        self.assertTrue(all(cid == correlation_ids[0] for cid in correlation_ids[1:]))


### PR DESCRIPTION
This should be able to handle most cases of context propagation between jobs.

This doesn't have a strong opinion on _what_ context is propagated and instead just allows for arbitrary metadata. This should work for OpenTracing, DataDog tracing, asgi-correlation-id, etc.

@tobymao 
@sondrelg
