### PR TITLE
continue to prune dict

### DIFF
--- a/saq/job.py
+++ b/saq/job.py
@@ -77,7 +77,7 @@ class Job:
         queued: job enqueued time epoch seconds
         started: job started time epoch seconds
         touched: job touched/updated time epoch seconds
-        results: dictionary containing the results, this is the return of the function provided, must be serializable, defaults to json
+        results: payload containing the results, this is the return of the function provided, must be serializable, defaults to json
         error: stack trace if an runtime error occurs
         status: Status Enum, defaulst to Status.New
     """
@@ -147,6 +147,10 @@ class Job:
         for field in dataclasses.fields(self):
             key = field.name
             value = getattr(self, key)
+            if value == field.default:
+                continue
+            if key == "meta" and not value:
+                continue
             if key == "queue" and value:
                 value = value.name
             result[key] = value

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -83,3 +83,12 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         self.assertAlmostEqual(job.next_retry_delay(), 1.0)
         job = Job("f", retry_delay=1.0, retry_backoff=True, attempts=3)
         self.assertTrue(0 <= job.next_retry_delay() < 4)
+
+    async def test_to_dict(self):
+        assert Job("f", key="a").to_dict() == {"function": "f", "key": "a"}
+        assert Job("f", key="a", meta={"x": 1}, queue=self.queue).to_dict() == {
+            "function": "f",
+            "key": "a",
+            "queue": self.queue.name,
+            "meta": {"x": 1},
+        }


### PR DESCRIPTION
@barakalon wasn't that hard to continue pruning results, default for the dataclass just returns MISSING_VALUE which is fine. 