### PR TITLE
Fix bug with queue map timeouts

### DIFF
--- a/saq/queue.py
+++ b/saq/queue.py
@@ -532,7 +532,7 @@ class Queue:
         # Start listening before we enqueue the jobs.
         # This ensures we don't miss any updates.
         task = asyncio.create_task(
-            self.listen(pending_job_keys, callback, timeout=timeout)
+            self.listen(pending_job_keys, callback, timeout=None)
         )
 
         try:


### PR DESCRIPTION
@tobymao 
@barakalon 
While using `queue.apply()`, I would sometimes get a Redis ConnectionError instead of the expected asyncio TimeoutError. It looks like the listen task in map() is wrapped in an asyncio.wait_for(), but listen() already uses an asyncio.wait_for() of its own. Since they both have the same timeout, the outer wait_for()'s cancellation can sometimes interfere with listen()'s wait_for's cancellation if it's taking some time to clean up, e.g. close and clean up the redis connection. This PR passes `None` to listen()'s timeout and lets `queue.map()` handle timing out the listen() task.