### PR TITLE
Allow users to expire, keep, or disable storage of job information

### DIFF
--- a/saq/job.py
+++ b/saq/job.py
@@ -60,7 +60,7 @@ class Job:
         heartbeat: the maximum amount of time a job can survive without a heartebat in seconds, defaults to 0 (disabled)
             a heartbeat can be triggered manually within a job by calling await job.update()
         retries: the maximum number of attempts to retry a job, defaults to 1
-        ttl: the maximum time in seconds to store information about a job including results, defaults to 600
+        ttl: the maximum time in seconds to store information about a job including results, defaults to 600 (0 means indefinitely, -1 means disabled)
         retry_delay: seconds to delay before retrying the job
         retry_backoff: If true, use exponential backoff for retry delays.
             The first retry will have whatever retry_delay is.

--- a/saq/queue.py
+++ b/saq/queue.py
@@ -374,6 +374,8 @@ class Queue:
                 pipe = pipe.setex(job_id, job.ttl, self.serialize(job))
             elif job.ttl == 0:
                 pipe = pipe.set(job_id, self.serialize(job))
+            else:
+                pipe.delete(job_id)
 
             await pipe.execute()
 

--- a/saq/queue.py
+++ b/saq/queue.py
@@ -370,9 +370,9 @@ class Queue:
         async with self.redis.pipeline(transaction=True) as pipe:
             pipe = pipe.lrem(self._active, 1, job_id).zrem(self._incomplete, job_id)
 
-            if job.ttl:
+            if job.ttl > 0:
                 pipe = pipe.setex(job_id, job.ttl, self.serialize(job))
-            else:
+            elif job.ttl == 0:
                 pipe = pipe.set(job_id, self.serialize(job))
 
             await pipe.execute()


### PR DESCRIPTION
Currently, the information attached to a job that has been processed are necessarily stored back in redis. In some cases, this is not needed, and unwanted.

I added a way for users to disable this feature by making the ttl have three states:
- positive (e.g. 600): the job is saved back to redis with an expiry after processing
- neutral (e.g. 0): the job is saved back to redis without expiry
- negative (e.g. -1): the job is not saved back to redis

I thought about using positive, None, and 0, but decided to stay with one type, not sure what's best honestly.