### PR TITLE
Periodic task decorator

### DIFF
--- a/examples/monitored.py
+++ b/examples/monitored.py
@@ -10,7 +10,7 @@ logger.setLevel(logging.DEBUG)
 
 @monitored_job
 async def monitored_sleeper(ctx):
-    print("executing monitored sleeper job.")
+    logger.info("executing monitored sleeper job.")
 
     await asyncio.sleep(30)
     return {"a": 6}
@@ -18,19 +18,19 @@ async def monitored_sleeper(ctx):
 
 async def sleeper(ctx):
     await asyncio.sleep(30)
-    print("executing regular sleeper job.  I should fail due to missed heartbeat")
+    logger.info("executing regular sleeper job.  I should fail due to missed heartbeat")
 
     return {"a": 6}
 
 
 @monitored_job
 async def monitored_cron_job(ctx):
-    print("excuting cron job")
+    logger.info("excuting cron job")
     await asyncio.sleep(6)
 
 
 async def cron_job(ctx):
-    print("excuting regular cron job.  I should fail due to missed heartbeat")
+    logger.info("excuting regular cron job.  I should fail due to missed heartbeat")
     await asyncio.sleep(6)
 
 
@@ -51,12 +51,11 @@ async def enqueue(func, **kwargs):
         func,
         heartbeat=3,
     )
-    print(result)
+    logger.info(result)
 
 
 if __name__ == "__main__":
     now = time.time()
     asyncio.run(enqueue("monitored_sleeper"))
     asyncio.run(enqueue("sleeper"))
-
-    print(time.time() - now)
+    logger.info(time.time() - now)

--- a/examples/monitored.py
+++ b/examples/monitored.py
@@ -1,0 +1,62 @@
+import asyncio
+import logging
+import time
+
+from saq import CronJob, Queue, monitored_job
+
+logger = logging.getLogger("saq")
+logger.setLevel(logging.DEBUG)
+
+
+@monitored_job
+async def monitored_sleeper(ctx):
+    print("executing monitored sleeper job.")
+
+    await asyncio.sleep(30)
+    return {"a": 6}
+
+
+async def sleeper(ctx):
+    await asyncio.sleep(30)
+    print("executing regular sleeper job.  I should fail due to missed heartbeat")
+
+    return {"a": 6}
+
+
+@monitored_job
+async def monitored_cron_job(ctx):
+    print("excuting cron job")
+    await asyncio.sleep(6)
+
+
+async def cron_job(ctx):
+    print("excuting regular cron job.  I should fail due to missed heartbeat")
+    await asyncio.sleep(6)
+
+
+settings = {
+    "functions": [monitored_sleeper, monitored_cron_job, sleeper, cron_job],
+    "concurrency": 100,
+    "timers": {"sweep": 5},
+    "cron_jobs": [
+        CronJob(monitored_cron_job, cron="* * * * * */20", heartbeat=2, timeout=None),
+        CronJob(cron_job, cron="* * * * * */20", heartbeat=2, timeout=None),
+    ],
+}
+
+
+async def enqueue(func, **kwargs):
+    queue = Queue.from_url("redis://localhost")
+    result = await queue.apply(
+        func,
+        heartbeat=3,
+    )
+    print(result)
+
+
+if __name__ == "__main__":
+    now = time.time()
+    asyncio.run(enqueue("monitored_sleeper"))
+    asyncio.run(enqueue("sleeper"))
+
+    print(time.time() - now)

--- a/saq/__init__.py
+++ b/saq/__init__.py
@@ -1,4 +1,4 @@
-from saq.job import CronJob, Job, Status
+from saq.job import CronJob, Job, Status, monitored_job
 from saq.queue import Queue
 from saq.worker import Worker
 

--- a/saq/job.py
+++ b/saq/job.py
@@ -187,8 +187,6 @@ class Job:
     def stuck(self):
         """Checks if an active job is passed it's timeout or heartbeat."""
         current = now()
-        # if timeout == None, the if statement will fail for
-        # TypeError: '>' not supported between instances of 'float' and 'NoneType'
         return (self.status == Status.ACTIVE) and (
             (self.timeout and seconds(current - self.started) > self.timeout)
             or (self.heartbeat and seconds(current - self.touched) > self.heartbeat)


### PR DESCRIPTION
I've been using this decorator to enable jobs to automatically execute `update` on an interval.

The decorator determines if the job has a heartbeat setting enabled, and if so, it automatically ticks while the job is executing.

The current formula for how often to tick is the following:  `max(round(job.heartbeat/2),1)`.  

I've added an example of how it works in the `examples/monitored.py`, and I took a shot at test cases.

```python
from saq.job import monitored_job

@monitored_job
async def monitored_sleeper(ctx):
    await asyncio.sleep(ctx.get("sleep", 10))
    return {"a": 1, "b": []}
```

The heartbeat will automatically start once you've scheduled a job for this function with `job.heartbeat` 

```python
await queue.apply(
        func,
        heartbeat=3,
    )
```

After starting a job with the decorator applied, you'll see that it's executing periodically in the logs:
```
INFO:saq:Processing Job<function=monitored_cron_job, queue=default, id=saq:job:default:cron:monitored_cron_job, scheduled=1654467040, progress=0.0, start_ms=16107, attempts=1, status=active, meta={}>
INFO:saq:starting heartbeat service for saq:job:default:cron:monitored_cron_job. Ticking every 1 second(s)
excuting cron job
INFO:saq:ticking heartbeat for saq:job:default:cron:monitored_cron_job, and sleeping for 1 second(s)
INFO:saq:stopping heartbeat service for saq:job:default:cron:monitored_cron_job
```