### PR TITLE
Fixes warnings from running `run_checks.sh`.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -10,7 +10,6 @@ disable=
     missing-function-docstring,
     missing-module-docstring,
     no-self-argument,
-    no-self-use,
     too-few-public-methods,
     too-many-lines,
     too-many-public-methods,

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -27,6 +27,7 @@ class TestWorker(AioHTTPTestCase):
     async def asyncTearDown(self):
         await cleanup_queue(self.queue1)
         await cleanup_queue(self.queue2)
+        await super().asyncTearDown()
 
     async def test_queues(self):
         async with self.client.get("/api/queues") as resp:


### PR DESCRIPTION
- closes the aiohttp session after each test
- removes 'no-self-use' from .pylintrc disable= section (useless-option-value)