### PR TITLE
Fix worker queue settings

### DIFF
--- a/saq/worker.py
+++ b/saq/worker.py
@@ -310,7 +310,7 @@ def start(
 ) -> None:
     settings_obj = import_settings(settings)
 
-    if "queue" not in settings:
+    if "queue" not in settings_obj:
         settings_obj["queue"] = Queue.from_url("redis://localhost")
 
     loop = asyncio.new_event_loop()


### PR DESCRIPTION
This fixes a bug where the worker didn't pick up the correct queue when starting causing it to always use `default` on localhost