### PR TITLE
Clean up signal handlers after shutdown event is triggered

### DIFF
--- a/saq/worker.py
+++ b/saq/worker.py
@@ -131,6 +131,9 @@ class Worker:
                 self._process()
 
             await self.event.wait()
+
+            for signum in self.SIGNALS:
+                loop.remove_signal_handler(signum)
         finally:
             logger.info("Shutting down")
 


### PR DESCRIPTION
This allows subsequent signals to propagate after the shutdown is triggered. Useful when debugging since you might have some other tasks that didn't finish you want to stop (read spam CTRL-C 😄), without this patch only way to stop the python program is to send a SIGKILL