### PR TITLE
Add option to have SAQ use fifo instead of filo

### DIFF
--- a/saq/queue.py
+++ b/saq/queue.py
@@ -76,7 +76,6 @@ class Queue:
         dump: DumpType | None = None,
         load: LoadType | None = None,
         max_concurrent_ops: int = 20,
-        fifo: bool = False,
     ) -> None:
         self.redis = redis
         self.name = name
@@ -100,9 +99,6 @@ class Queue:
         self._load = load or json.loads
         self._before_enqueues: dict[int, BeforeEnqueueType] = {}
         self._op_sem = asyncio.Semaphore(max_concurrent_ops)
-        self._move_opts: list[t.Literal["LEFT", "RIGHT"]] = (
-            ["LEFT", "RIGHT"] if fifo else ["RIGHT", "LEFT"]
-        )
 
     def register_before_enqueue(self, callback: BeforeEnqueueType) -> None:
         self._before_enqueues[id(callback)] = callback
@@ -435,8 +431,8 @@ class Queue:
                 self._queued,
                 self._active,
                 timeout,
-                self._move_opts[0],  # source
-                self._move_opts[1],  # destination
+                "LEFT",
+                "RIGHT",
             )
         if job_id is not None:
             return await self._get_job_by_id(job_id)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -106,7 +106,7 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
 
     async def test_dequeue_fifo(self) -> None:
         await cleanup_queue(self.queue)
-        self.queue = create_queue(**{"fifo": True})
+        self.queue = create_queue()
         job = await self.enqueue("test")
         job_second = await self.enqueue("test_second")
         self.assertEqual(await self.count("queued"), 2)


### PR DESCRIPTION
Currently SAQ uses first in last out by default. 
This can create problems if lots of new jobs are being enqueued. Leaving this as the current default behavior to not surprise anyone, but creating an option to change it. 