### PR TITLE
Includes the current path as a module path to allow importlib finding in-development modules

### DIFF
--- a/saq/__main__.py
+++ b/saq/__main__.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import multiprocessing
+import os
 import sys
 
 from saq.worker import check_health, start
@@ -53,6 +54,9 @@ def main() -> None:
     )
 
     args = parser.parse_args()
+
+    # Includes the current path as a module path to allow importlib finding in-development modules
+    sys.path.append(os.getcwd())
 
     if not args.quiet:
         level = args.verbose


### PR DESCRIPTION
If you are busy developing and didn't do a `pip install -e .` yet, `saq foo.settings` is not equivalent to `python -m saq foo.settings` due to the prior only having access to installed modules.

This adds the current path to the module path so that it will work for both cases.