### PR TITLE
Fetch outstanding jobs from incomplete namespace instead of queued.

### DIFF
--- a/saq/queue.py
+++ b/saq/queue.py
@@ -168,14 +168,10 @@ class Queue:
             deserialized_jobs = (
                 self.deserialize(job_bytes)
                 for job_bytes in await self.redis.mget(
-                    (
-                        await self.redis.lrange(
-                            self.namespace("active"), offset, limit - 1
-                        )
-                    )
+                    (await self.redis.lrange(self._active, offset, limit - 1))
                     + (
-                        await self.redis.lrange(
-                            self.namespace("queued"), offset, limit - 1
+                        await self.redis.zrange(
+                            self._incomplete, offset, limit - 1, withscores=False
                         )
                     )
                 )


### PR DESCRIPTION
This is because the web interface will hide jobs that are rescheduled. 
I replaced queued with incomplete because it looks like incomplete is a superset of it.