### PR TITLE
Added package saq.web to build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
-## Next
-- `saq` command-line client includes current path to simplify development
+## v0.11
+
+### v0.11.2
+- Added package `saq.web` to build
+
+### v0.11.1
 - Added embeddable `saq.web.starlette`
+
+### v0.11.0
+- `saq` command-line client includes current path to simplify development
+- Fetch outstanding jobs from incomplete namespace instead of queued.
 - Documentation now hosted on [Read The Docs](https://saq-py.readthedocs.io/)
 
 ## v0.10

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,10 @@ setup(
     author="Toby Mao",
     author_email="toby.mao@gmail.com",
     license="MIT",
-    packages=["saq"],
+    packages=[
+        "saq",
+        "saq.web",
+    ],
     include_package_data=True,
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
Hi, thanks for releasing a new version, but it seems that the saq.web pacakges are not included. (my bad, I didn't verify that setup.py didn't use `find_packages()`)

I also updated the CHANGELOG assuming the next release should be called v0.11.2