### PR TITLE
Test utility

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,53 @@
+# Testing
+
+SAQ provides a basic test double that can make writing your tests a bit more convenient.
+
+## Usage
+If your code only uses {py:class}`saq.queue.Queue.enqueue`:
+```py
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+from saq.testing import TestQueue
+from tests.testing.tasks import enqueues_a_job
+
+# If you want to assert queue behavior
+with patch("tests.testing.tasks.queue", new=TestQueue()) as testqueue:
+    await enqueues_a_job()
+    testqueue.assertEnqueuedTimes("thetask", 1)
+
+# You can also just wrap a class or method if you don't need to inspect the queue    
+@patch("tests.testing.tasks.queue", new=TestQueue())
+class TestWrapped(IsolatedAsyncioTestCase):
+    ...
+```
+
+If you need to test something that uses {py:class}`saq.queue.Queue.apply` or {py:class}`saq.queue.Queue.map` you need to pass in the worker settings:
+```py
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+from saq.testing import TestQueue
+from tests.testing.tasks import applies_a_job, settings
+
+@patch("tests.testing.tasks.queue", new=TestQueue(settings))
+class TestApplies(IsolatedAsyncioTestCase):
+    async def test_apply(self) -> None:
+        self.assertEqual(
+            await applies_a_job(),
+            8
+        )
+        # Task "add" called directly
+```
+
+## Caveats
+
+It's important to patch the entire path of where you queue object is.
+If you want to call on the queue directly, {py:class}`unittest.mock` has a caveat that if you 
+
+
+## Provided assertions
+
+```{eval-rst}
+.. autoapiclass:: saq.testing.TestQueue
+    :noindex:
+    :members: getEnqueued, assertEnqueuedTimes, assertNotEnqueued, getRetried, assertRetriedTimes, assertNotRetried
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,4 +10,5 @@ queue
 worker
 settings
 monitoring
+testing
 ```

--- a/saq/__init__.py
+++ b/saq/__init__.py
@@ -4,8 +4,10 @@ SAQ
 from saq.job import CronJob, Job, Status
 from saq.queue import Queue
 from saq.worker import Worker
+from saq.types import Context
 
 __all__ = [
+    "Context",
     "CronJob",
     "Job",
     "Queue",

--- a/saq/testing.py
+++ b/saq/testing.py
@@ -33,6 +33,7 @@ class TestQueue(Queue):
     Raises:
         AssertionError: If both `worker` and `settings` have been provided.
     """
+
     def __init__(
         self, *, worker: Worker | None = None, settings: dict[str, t.Any] | None = None
     ) -> None:

--- a/saq/testing.py
+++ b/saq/testing.py
@@ -1,0 +1,122 @@
+import typing as t
+from collections.abc import Sequence
+from unittest.mock import AsyncMock
+
+from redis.asyncio.client import Redis
+
+from saq.job import Job, Status
+from saq.queue import Queue
+from saq.utils import now
+from saq.worker import Worker
+
+
+class TestWorker(Worker):
+    def __init__(self, settings_obj: dict[str, t.Any]) -> None:
+        settings_obj["queue"] = AsyncMock(Queue)
+        super().__init__(**settings_obj)
+
+
+class TestQueue(Queue):
+    def __init__(
+        self, *, worker: Worker | None = None, settings: dict[str, t.Any] | None = None
+    ) -> None:
+        super().__init__(redis=AsyncMock(spec=Redis))
+        self._worker: Worker | None = None
+        self._enqueued: list[Job] = []
+        self._retried: list[Job] = []
+
+        if worker and settings:
+            raise AssertionError("Please provide worker or settings, not both")
+
+        if worker:
+            self._worker = worker
+        elif settings:
+            self._worker = TestWorker(settings)
+        if self._worker:
+            self._worker.queue = self
+
+    async def update(self, job: Job) -> None:
+        job.touched = now()
+
+    async def abort(self, job: Job, error: str, ttl: float = 5) -> None:
+        await job.finish(Status.ABORTED, error=error)
+
+    async def _finish(self, job: Job, status: Status) -> None:
+        return
+
+    async def _retry(self, job: Job) -> None:
+        self._retried.append(job)
+
+    async def enqueue(self, job_or_func: str | Job, **kwargs: t.Any) -> Job:
+        job = self.get_job(job_or_func, **kwargs)
+        self._enqueued.append(job)
+        return job
+
+    async def map(
+        self,
+        job_or_func: str | Job,
+        iter_kwargs: Sequence[dict[str, t.Any]],
+        timeout: float | None = None,
+        return_exceptions: bool = False,
+        **kwargs: t.Any,
+    ) -> list[t.Any]:
+        if not self._worker:
+            raise AssertionError(
+                "Please pass in a settings object so a worker can be faked"
+            )
+
+        jobs: list[Job] = [
+            self.get_job(job_or_func, timeout=timeout, **kwargs, **kw)
+            for kw in iter_kwargs
+        ]
+        return await self._map(
+            [self._worker.process_job(job) for job in jobs], return_exceptions
+        )
+
+    #########################################################################
+    # Test assertion methods
+    #########################################################################
+
+    def getEnqueued(self, job_name: str, *, kwargs: dict | None = None) -> list[Job]:
+        jobs = [job for job in self._enqueued if job.function == job_name]
+        if kwargs:
+            jobs = [job for job in jobs if job.kwargs == kwargs]
+        return jobs
+
+    def assertEnqueuedTimes(
+        self, job_name: str, times: int, kwargs: dict | None = None
+    ) -> None:
+        jobs = self.getEnqueued(job_name, kwargs=kwargs)
+
+        if len(jobs) != times:
+            raise AssertionError(
+                f"Job '{job_name}' called {len(jobs)} times, expected {times}"
+            )
+
+    def assertNotEnqueued(self, job_name: str, *, kwargs: dict | None = None) -> None:
+        jobs = self.getEnqueued(job_name, kwargs=kwargs)
+
+        if jobs:
+            raise AssertionError(f"Job '{job_name}' called unexpectedly")
+
+    def getRetried(self, job_name: str, *, kwargs: dict | None = None) -> list[Job]:
+        jobs = [job for job in self._retried if job.function == job_name]
+        if kwargs:
+            jobs = [job for job in jobs if job.kwargs == kwargs]
+        return jobs
+
+    def assertRetriedTimes(
+        self, job_name: str, times: int, kwargs: dict | None = None
+    ) -> None:
+        jobs = self.getRetried(job_name, kwargs=kwargs)
+
+        if len(jobs) != times:
+            raise AssertionError(
+                f"Job '{job_name}' retried {len(jobs)} times, expected {times}"
+            )
+
+    def assertNotRetried(self, job_name: str, *, kwargs: dict | None = None) -> None:
+        jobs = self.getRetried(job_name, kwargs=kwargs)
+
+        if jobs:
+            raise AssertionError(f"Job '{job_name}' retried unexpectedly")

--- a/saq/testing.py
+++ b/saq/testing.py
@@ -1,3 +1,6 @@
+"""
+Testing helpers
+"""
 from __future__ import annotations
 
 import typing as t
@@ -19,6 +22,17 @@ class TestWorker(Worker):
 
 
 class TestQueue(Queue):
+    """
+    This is a test double of Queue, it's used in testing.
+    Please refer to the Testing documentation for more detail.
+
+    Args:
+        worker: Optional worker instance
+        settings: Optional settings dict
+
+    Raises:
+        AssertionError: If both `worker` and `settings` have been provided.
+    """
     def __init__(
         self, *, worker: Worker | None = None, settings: dict[str, t.Any] | None = None
     ) -> None:
@@ -80,6 +94,13 @@ class TestQueue(Queue):
     #########################################################################
 
     def getEnqueued(self, job_name: str, *, kwargs: dict | None = None) -> list[Job]:
+        """
+        Get jobs that have been enqueued, filtered by `job_name` and `kwargs`
+
+        Args:
+            job_name: Job name to filter by
+            kwargs: Exact match of kwargs of job. (optional)
+        """
         jobs = [job for job in self._enqueued if job.function == job_name]
         if kwargs:
             jobs = [job for job in jobs if job.kwargs == kwargs]
@@ -88,6 +109,17 @@ class TestQueue(Queue):
     def assertEnqueuedTimes(
         self, job_name: str, times: int, kwargs: dict | None = None
     ) -> None:
+        """
+        Asserts that the job(s) have been enqueued.
+
+        Args:
+            job_name: Job name to filter by
+            times: Times the job was expected to be enqueued
+            kwargs: Exact match of kwargs of job. (optional)
+
+        Raises:
+            AssertionError: If job has not been enqueued the right amount of times.
+        """
         jobs = self.getEnqueued(job_name, kwargs=kwargs)
 
         if len(jobs) != times:
@@ -96,12 +128,29 @@ class TestQueue(Queue):
             )
 
     def assertNotEnqueued(self, job_name: str, *, kwargs: dict | None = None) -> None:
+        """
+        Asserts that the job(s) have **not** been enqueued.
+
+        Args:
+            job_name: Job name to filter by
+            kwargs: Exact match of kwargs of job. (optional)
+
+        Raises:
+            AssertionError: If job has not been enqueued.
+        """
         jobs = self.getEnqueued(job_name, kwargs=kwargs)
 
         if jobs:
             raise AssertionError(f"Job '{job_name}' called unexpectedly")
 
     def getRetried(self, job_name: str, *, kwargs: dict | None = None) -> list[Job]:
+        """
+        Get jobs that have been retried, filtered by `job_name` and `kwargs`
+
+        Args:
+            job_name: Job name to filter by
+            kwargs: Exact match of kwargs of job. (optional)
+        """
         jobs = [job for job in self._retried if job.function == job_name]
         if kwargs:
             jobs = [job for job in jobs if job.kwargs == kwargs]
@@ -110,6 +159,17 @@ class TestQueue(Queue):
     def assertRetriedTimes(
         self, job_name: str, times: int, kwargs: dict | None = None
     ) -> None:
+        """
+        Asserts that the job(s) have been retried.
+
+        Args:
+            job_name: Job name to filter by
+            times: Times the job was expected to be retried
+            kwargs: Exact match of kwargs of job. (optional)
+
+        Raises:
+            AssertionError: If job has not been retried the right amount of times.
+        """
         jobs = self.getRetried(job_name, kwargs=kwargs)
 
         if len(jobs) != times:
@@ -118,6 +178,16 @@ class TestQueue(Queue):
             )
 
     def assertNotRetried(self, job_name: str, *, kwargs: dict | None = None) -> None:
+        """
+        Asserts that the job(s) have **not** been retried..
+
+        Args:
+            job_name: Job name to filter by
+            kwargs: Exact match of kwargs of job. (optional)
+
+        Raises:
+            AssertionError: If job has been retried.
+        """
         jobs = self.getRetried(job_name, kwargs=kwargs)
 
         if jobs:

--- a/saq/testing.py
+++ b/saq/testing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing as t
 from collections.abc import Sequence
 from unittest.mock import AsyncMock

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         saq=saq.__main__:main
     """,
     install_requires=[
-        "redis>=4.2,<5.0",
+        "redis>=4.2,<6.0",
         "croniter>=0.3.18",
     ],
     extras_require={

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -128,6 +128,7 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
         task = asyncio.get_running_loop().create_task(self.dequeue())
         self.assertEqual(await self.count("queued"), 1)
         self.assertEqual(await self.count("incomplete"), 3)
+        await asyncio.sleep(0.05)
         self.assertEqual(await self.count("active"), 3)
         await task
         self.assertEqual(await self.count("incomplete"), 3)

--- a/tests/testing/tasks.py
+++ b/tests/testing/tasks.py
@@ -1,0 +1,30 @@
+from saq import Context, Job, Queue
+
+
+async def add(  # pylint: disable=unused-argument
+    ctx: Context, *, val1: int, val2: int
+) -> int:
+    return val1 + val2
+
+
+async def boom(ctx: Context, *, value: str) -> int:  # pylint: disable=unused-argument
+    raise ValueError(value)
+
+
+queue = Queue.from_url("redis://localhost")
+settings = {
+    "queue": queue,
+    "functions": [add, boom],
+}
+
+
+async def applies_a_job() -> int:
+    return await queue.apply("add", val1=7, val2=11)
+
+
+async def enqueues_a_job() -> Job:
+    return await queue.enqueue("add", val1=7, val2=11)  # type: ignore
+
+
+async def enqueues_a_job_that_retries() -> Job:
+    return await queue.enqueue("boom", value="For retrying", retries=10)  # type: ignore

--- a/tests/testing/test_assert.py
+++ b/tests/testing/test_assert.py
@@ -1,0 +1,73 @@
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+from saq import Status, Job
+from saq.testing import TestQueue, TestWorker
+from tests.testing.tasks import enqueues_a_job, settings, enqueues_a_job_that_retries
+
+
+class TestAssertions(IsolatedAsyncioTestCase):
+    async def test_indirect_enqueue(self) -> None:
+        with patch("tests.testing.tasks.queue", new=TestQueue()) as testqueue:
+            job = await enqueues_a_job()
+
+            testqueue.assertEnqueuedTimes("add", 1)
+            testqueue.assertNotEnqueued("boom")
+            testqueue.assertNotRetried("add")
+
+            self.assertEqual([job], testqueue.getEnqueued("add"))
+
+    async def test_indirect_enqueue_with_kwargs(self) -> None:
+        with patch("tests.testing.tasks.queue", new=TestQueue()) as testqueue:
+            await enqueues_a_job()
+
+            testqueue.assertEnqueuedTimes("add", 1, kwargs={"val1": 7, "val2": 11})
+            testqueue.assertNotEnqueued("boom")
+            testqueue.assertNotRetried("add")
+
+    async def test_testqueue_both_settings_worker(self) -> None:
+        worker = TestWorker(settings)
+        with self.assertRaises(AssertionError):
+            TestQueue(settings=settings, worker=worker)
+
+    async def test_failed_enequeued_times(self) -> None:
+        with patch("tests.testing.tasks.queue", new=TestQueue()) as testqueue:
+            await enqueues_a_job()
+
+            with self.assertRaises(AssertionError):
+                testqueue.assertNotEnqueued("add")
+            with self.assertRaises(AssertionError):
+                testqueue.assertEnqueuedTimes("add", 2)
+            with self.assertRaises(AssertionError):
+                testqueue.assertEnqueuedTimes("boom", 1)
+            with self.assertRaises(AssertionError):
+                testqueue.assertRetriedTimes("add", 1)
+
+    async def test_enqueue_retry(self) -> None:
+        worker = TestWorker(settings)
+        with patch(
+            "tests.testing.tasks.queue", new=TestQueue(worker=worker)
+        ) as testqueue:
+            job: Job = await enqueues_a_job_that_retries()
+            self.assertIsNotNone(job)
+            self.assertEqual(job.status, Status.QUEUED)
+            testqueue.assertEnqueuedTimes("boom", 1)
+            testqueue.assertNotRetried("boom")
+
+            with self.assertRaises(AssertionError):
+                testqueue.assertRetriedTimes("boom", 1)
+
+            await worker.process_job(job)
+
+            self.assertEqual(job.status, Status.QUEUED)
+            testqueue.assertRetriedTimes("boom", 1)
+            testqueue.assertRetriedTimes("boom", 1, kwargs={"value": "For retrying"})
+
+            with self.assertRaises(AssertionError):
+                testqueue.assertNotRetried("boom")
+
+            await worker.process_job(job)
+            testqueue.assertRetriedTimes("boom", 2)
+
+            await job.abort("Gave up")
+            self.assertEqual(job.status, Status.ABORTED)

--- a/tests/testing/test_settings.py
+++ b/tests/testing/test_settings.py
@@ -1,0 +1,19 @@
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+from saq.queue import JobError
+from saq.testing import TestQueue
+from tests.testing import tasks
+
+
+@patch("tests.testing.tasks.queue", new=TestQueue(settings=tasks.settings))
+class TestSimple(IsolatedAsyncioTestCase):
+    async def test_indirect_apply(self) -> None:
+        self.assertEqual(await tasks.applies_a_job(), 18)
+
+    async def test_apply_add(self) -> None:
+        self.assertEqual(await tasks.queue.apply("add", val1=5, val2=7), 12)
+
+    async def test_apply_boom(self) -> None:
+        with self.assertRaisesRegex(JobError, "Boom!"):
+            await tasks.queue.apply("boom", value="Boom!")

--- a/tests/testing/test_simple.py
+++ b/tests/testing/test_simple.py
@@ -1,0 +1,30 @@
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+from saq import Job, Status
+from saq.testing import TestQueue
+from tests.testing import tasks
+
+
+@patch("tests.testing.tasks.queue", new=TestQueue())
+class TestSimple(IsolatedAsyncioTestCase):
+    async def test_queue(self) -> None:
+        job: Job = await tasks.queue.enqueue("add", val1=3, val2=5, timeout=10)  # type: ignore
+
+        self.assertIsInstance(job, Job)
+        self.assertEqual(job.function, "add")
+        self.assertEqual(job.timeout, 10)
+        self.assertEqual(job.status, Status.QUEUED)
+        self.assertEqual(job.kwargs, {"val1": 3, "val2": 5})
+
+    async def test_apply_fail(self) -> None:
+        with self.assertRaises(AssertionError):
+            await tasks.queue.apply("add", val1=3, val2=5)
+
+    async def test_indirect_apply_fail(self) -> None:
+        with self.assertRaises(AssertionError):
+            await tasks.applies_a_job()
+
+    async def test_indirect_enqueue(self) -> None:
+        job = await tasks.enqueues_a_job()
+        self.assertIsInstance(job, Job)

--- a/tests/testing/test_worker.py
+++ b/tests/testing/test_worker.py
@@ -1,0 +1,32 @@
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+from saq import Status, Job
+from saq.queue import JobError
+from saq.testing import TestQueue, TestWorker
+from tests.testing import tasks
+
+worker = TestWorker(tasks.settings)
+
+
+@patch("tests.testing.tasks.queue", new=TestQueue(worker=worker))
+class TestSimple(IsolatedAsyncioTestCase):
+    async def test_queue(self) -> None:
+        job: Job = await tasks.queue.enqueue("add", val1=3, val2=5, timeout=10)  # type: ignore
+
+        self.assertIsInstance(job, Job)
+
+        await worker.process_job(job)
+
+        self.assertEqual(job.status, Status.COMPLETE)
+        self.assertEqual(job.result, 8)
+
+    async def test_indirect_apply(self) -> None:
+        self.assertEqual(await tasks.applies_a_job(), 18)
+
+    async def test_apply_add(self) -> None:
+        self.assertEqual(await tasks.queue.apply("add", val1=3, val2=5), 8)
+
+    async def test_apply_boom(self) -> None:
+        with self.assertRaisesRegex(JobError, "Boom!"):
+            await tasks.queue.apply("boom", value="Boom!")


### PR DESCRIPTION
This PR contains a simple test double for testing your app that uses SAQ a bit easier.
This doesn't require a redis server running, or using a fake redis server to test. It's really only aimed at the more common use cases

Done:
* [x] Refactored  `saq/queue.py` and `saq/worker.py` to ensure that the provided test doubles use much more of the actual code.
* [x] New test doubles in `saq/testing.py`
* [x] Test suite includes tests that use the test doubles
* [x] Wrote documentation

To use you could do, e.g.:
```py
from unittest import IsolatedAsyncioTestCase
from unittest.mock import patch

from saq.testing import TestQueue
from tests.testing.tasks import enqueues_a_job

@patch("tests.testing.tasks.queue", new=TestQueue())
class TestSimple(IsolatedAsyncioTestCase):
    def test_ignore_that_a_job_got_enqueued(self) -> None:
        await enqueues_a_job()
        # It didn't connect to redis
```

Or more typically:
```py
from unittest import IsolatedAsyncioTestCase
from unittest.mock import patch

from saq.testing import TestQueue
from tests.testing.tasks import enqueues_a_job


class TestTypically(IsolatedAsyncioTestCase):
    async def test_indirect_enqueue(self) -> None:
        with patch("tests.testing.tasks.queue", new=TestQueue()) as testqueue:
            await enqueues_a_job()

            testqueue.assertEnqueuedTimes("add", 1)
            # Verified that it enqueued the task "add"
            
    async def test_not_enqueue(self) -> None:
        with patch("tests.testing.tasks.queue", new=TestQueue()) as testqueue:
            testqueue.assertNotEnqueued("add")
            # Verified that task "add" was enqueued
```

If you need to test something that uses `queue.apply()` or `queue.map()` you can pass in the worker settings:
```py
from unittest import IsolatedAsyncioTestCase
from unittest.mock import patch

from saq.testing import TestQueue
from tests.testing.tasks import applies_a_job, settings

@patch("tests.testing.tasks.queue", new=TestQueue(settings))
class TestTypically(IsolatedAsyncioTestCase):
    async def test_apply(self) -> None:
        self.assertEqual(
            await applies_a_job(),
            8
        )
        # Task "add" called directly
```
