### PR TITLE
Support redis==5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         saq=saq.__main__:main
     """,
     install_requires=[
-        "redis>=4.2,<5.0",
+        "redis>=4.2,<6.0",
         "croniter>=0.3.18",
     ],
     extras_require={

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -128,6 +128,7 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
         task = asyncio.get_running_loop().create_task(self.dequeue())
         self.assertEqual(await self.count("queued"), 1)
         self.assertEqual(await self.count("incomplete"), 3)
+        await asyncio.sleep(0.05)
         self.assertEqual(await self.count("active"), 3)
         await task
         self.assertEqual(await self.count("incomplete"), 3)


### PR DESCRIPTION
Adding strategic sleep gives async process time to catch up.
No longer failing on redis==5.0
Also fixes flaky tests on redis<5