### PR TITLE
Silence SIGINT causing tracebacks of different process dumping to stderr

### DIFF
--- a/saq/__main__.py
+++ b/saq/__main__.py
@@ -82,12 +82,15 @@ def main() -> None:
                 p = multiprocessing.Process(target=start, args=(settings,))
                 p.start()
 
-        start(
-            settings,
-            web=args.web,
-            extra_web_settings=args.extra_web_settings,
-            port=args.port,
-        )
+        try:
+            start(
+                settings,
+                web=args.web,
+                extra_web_settings=args.extra_web_settings,
+                port=args.port,
+            )
+        except KeyboardInterrupt:
+            pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This confuses things, and at first I through there was no SIGINT handling, but it's there and it works.
It just prints spurious things if multiprocessing is used.