### PR TITLE
Logging verbosity balancing.

### DIFF
--- a/saq/__main__.py
+++ b/saq/__main__.py
@@ -62,7 +62,7 @@ def main() -> None:
         level = args.verbose
 
         if level == 0:
-            level = logging.ERROR
+            level = logging.WARNING
         elif level == 1:
             level = logging.INFO
         else:

--- a/saq/job.py
+++ b/saq/job.py
@@ -129,7 +129,20 @@ class Job:
     status: Status = Status.NEW
     meta: dict[t.Any, t.Any] = dataclasses.field(default_factory=dict)
 
-    def __repr__(self) -> str:
+    _EXCLUDE_NON_FULL = {
+        "kwargs",
+        "scheduled",
+        "progress",
+        "total_ms",
+        "result",
+        "error",
+        "status",
+        "meta",
+    }
+
+    def info(self, full: bool = False) -> str:
+        # Using an exclusion list preserves order for kwargs below
+        excluded = set() if full else self._EXCLUDE_NON_FULL
         kwargs = ", ".join(
             f"{k}={v}"
             for k, v in {
@@ -148,9 +161,12 @@ class Job:
                 "status": self.status,
                 "meta": self.meta,
             }.items()
-            if v is not None
+            if v is not None and k not in excluded
         )
         return f"Job<{kwargs}>"
+
+    def __repr__(self) -> str:
+        return self.info(True)
 
     def __hash__(self) -> int:
         return hash(self.key)


### PR DESCRIPTION
I prefer a modicum of logging to simplify diagnostics, but not too much.

* Default loglevel of `ERROR` was too restrictive as warnings won't get reported. I changed the default loglevel to include `WARNING`.
* The Worker would not log when it started up, so I added an `INFO` for that, it includes logging the `Queue` config being used for easy identification of the worker.
* The Worker now logs the configured functions as `DEBUG`.
* The `INFO` loglevel would dump the entire payload and extra data for each job which would fill up the logs with more data, this was quite a jump from no logs at all for job processing. I split it up so that if loglevel is `INFO` it will emit an abridged version of the Job, and if loglevel is `DEBUG` it will emit the full version. (I'm not 100% happy about this, but needed to just log less of the same data for INFO by default)