### PR TITLE
use redis.aclose instead of close

### DIFF
--- a/saq/queue.py
+++ b/saq/queue.py
@@ -148,7 +148,7 @@ class Queue:
 
     async def disconnect(self) -> None:
         await self._pubsub.close()
-        await self.redis.close()
+        await self.redis.aclose()
         await self.redis.connection_pool.disconnect()
 
     async def version(self) -> VersionTuple:


### PR DESCRIPTION
redis.close is deprecated since version 5.0.0