### PR TITLE
Update queue.py to support redis >= 5.* aclose method.

### DIFF
--- a/saq/queue.py
+++ b/saq/queue.py
@@ -148,7 +148,10 @@ class Queue:
 
     async def disconnect(self) -> None:
         await self._pubsub.close()
-        await self.redis.close()
+        if hasattr(self.redis, "aclose"):
+            await self.redis.aclose()
+        else:
+            await self.redis.close()
         await self.redis.connection_pool.disconnect()
 
     async def version(self) -> VersionTuple:


### PR DESCRIPTION
Use redis's aclose() method if available otherwise fallback to close().
Note: Follow-up to [PR #102](https://github.com/tobymao/saq/pull/102)
