### PR TITLE
Support settings factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ To start the worker, assuming the previous is available in the python path
 saq module.file.settings
 ```
 
+> **_Note:_** `module.file.settings` can also be a callable returning the settings dictionary.
+
 To enqueue jobs
 
 ```python

--- a/saq/worker.py
+++ b/saq/worker.py
@@ -312,7 +312,12 @@ def import_settings(settings: str) -> dict[str, t.Any]:
     # given a.b.c, parses out a.b as the module path and c as the variable
     module_path, name = settings.strip().rsplit(".", 1)
     module = importlib.import_module(module_path)
-    return getattr(module, name)
+    settings_obj = getattr(module, name)
+
+    if callable(settings_obj):
+        settings_obj = settings_obj()
+
+    return settings_obj
 
 
 def start(

--- a/tests/test_settings_import.py
+++ b/tests/test_settings_import.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import contextlib
+import secrets
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from saq.worker import import_settings
+
+
+class TestSettingsImport(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cm = cm = contextlib.ExitStack()
+
+        tempdir = Path(cm.enter_context(tempfile.TemporaryDirectory()))
+        root_module_name = "foo" + secrets.token_urlsafe(2)
+        file_tree = [
+            tempdir / root_module_name / "__init__.py",
+            tempdir / root_module_name / "bar" / "__init__.py",
+            tempdir / root_module_name / "bar" / "settings.py",
+        ]
+        for path in file_tree:
+            path.parent.mkdir(exist_ok=True, parents=True)
+            path.touch()
+
+        file_tree[-1].write_text(
+            textwrap.dedent(
+                """
+                static = {
+                    "functions": ["pretend_its_a_fn"],
+                    "concurrency": 100
+                }
+
+                def factory():
+                    return {
+                        "functions": ["pretend_its_some_other_fn"],
+                        "concurrency": static["concurrency"] + 100
+                    }
+                """
+            ).strip()
+        )
+        sys.path.append(str(tempdir))
+
+        self.module_path = f"{root_module_name}.bar.settings"
+
+    def tearDown(self) -> None:
+        self.cm.close()
+
+    def test_imports_settings_from_module_path(self) -> None:
+        settings = import_settings(self.module_path + ".static")
+
+        self.assertDictEqual(
+            settings,
+            {
+                "functions": ["pretend_its_a_fn"],
+                "concurrency": 100,
+            },
+        )
+
+    def test_calls_settings_factory(self) -> None:
+        settings = import_settings(self.module_path + ".factory")
+
+        self.assertDictEqual(
+            settings,
+            {
+                "functions": ["pretend_its_some_other_fn"],
+                "concurrency": 200,
+            },
+        )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2,20 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
-import contextlib
 import logging
-import secrets
-import sys
-import tempfile
-import textwrap
 import typing as t
 import unittest
 from unittest import mock
-from pathlib import Path
 
 from saq.job import CronJob, Job, Status
 from saq.utils import uuid1
-from saq.worker import Worker, import_settings
+from saq.worker import Worker
 from tests.helpers import cleanup_queue, create_queue
 
 if t.TYPE_CHECKING:
@@ -325,64 +319,3 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         correlation_ids = await self.queue.apply("recurse", n=2)
         self.assertEqual(len(correlation_ids), 3)
         self.assertTrue(all(cid == correlation_ids[0] for cid in correlation_ids[1:]))
-
-
-class TestSettingsImport(unittest.TestCase):
-    def setUp(self) -> None:
-        self.cm = cm = contextlib.ExitStack()
-
-        tempdir = Path(cm.enter_context(tempfile.TemporaryDirectory()))
-        root_module_name = "foo" + secrets.token_urlsafe(2)
-        file_tree = [
-            tempdir / root_module_name / "__init__.py",
-            tempdir / root_module_name / "bar" / "__init__.py",
-            tempdir / root_module_name / "bar" / "settings.py",
-        ]
-        for path in file_tree:
-            path.parent.mkdir(exist_ok=True, parents=True)
-            path.touch()
-
-        file_tree[-1].write_text(
-            textwrap.dedent(
-                """
-                static = {
-                    "functions": ["pretend_its_a_fn"],
-                    "concurrency": 100
-                }
-
-                def factory():
-                    return {
-                        "functions": ["pretend_its_some_other_fn"],
-                        "concurrency": static["concurrency"] + 100
-                    }
-                """
-            ).strip()
-        )
-        sys.path.append(str(tempdir))
-
-        self.module_path = f"{root_module_name}.bar.settings"
-
-    def tearDown(self) -> None:
-        self.cm.close()
-
-    def test_imports_settings_from_module_path(self) -> None:
-        settings = import_settings(self.module_path + ".static")
-
-        self.assertDictEqual(
-            settings,
-            {
-                "functions": ["pretend_its_a_fn"],
-                "concurrency": 100,
-            },
-        )
-
-    def test_calls_settings_factory(self) -> None:
-        settings = import_settings(self.module_path + ".factory")
-
-        self.assertDictEqual(
-            settings,
-            {
-                "functions": ["pretend_its_some_other_fn"],
-                "concurrency": 200,
-            },
-        )


### PR DESCRIPTION
Allow the settings objects imported during `saq.worker.start()` to be callable. This makes it possible to eliminate import-time side effects, especially if creating the settings objects is more involved.

In my case, I'm leveraging multiple queues and using a dependency injection framework to wire the `saq.Queue`s a certain way. While I could sequester the settings objects to their separate modules, I find it more convenient to keep them together.

Let me know if this idea is OK and thank you for this neat little framework!