### PR TITLE
fix: allow colons in job key

### DIFF
--- a/saq/__init__.py
+++ b/saq/__init__.py
@@ -1,6 +1,7 @@
 """
 SAQ
 """
+
 from saq.job import CronJob, Job, Status
 from saq.queue import Queue
 from saq.worker import Worker

--- a/saq/job.py
+++ b/saq/job.py
@@ -1,6 +1,7 @@
 """
 Jobs
 """
+
 from __future__ import annotations
 
 import dataclasses
@@ -182,11 +183,6 @@ class Job:
     def id(self) -> str:
         """Full Job ID"""
         return self.get_queue().job_id(self.key)
-
-    @classmethod
-    def key_from_id(cls, job_id: str) -> str:
-        """Key portion of Job ID"""
-        return job_id.split(":")[-1]
 
     @property
     def abort_id(self) -> str:

--- a/saq/queue.py
+++ b/saq/queue.py
@@ -1,6 +1,7 @@
 """
 Queues
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -126,6 +127,9 @@ class Queue:
 
     def job_id(self, job_key: str) -> str:
         return f"{ID_PREFIX}{self.name}:{job_key}"
+
+    def job_key_from_id(self, job_id: str) -> str:
+        return job_id[len(f"{ID_PREFIX}{self.name}:") :]
 
     async def _before_enqueue(self, job: Job) -> None:
         for cb in self._before_enqueues.values():
@@ -357,7 +361,7 @@ class Queue:
                 message = await queue.get()
                 queue.task_done()
                 job_id = message["channel"].decode("utf-8")
-                job_key = Job.key_from_id(job_id)
+                job_key = self.job_key_from_id(job_id)
                 status = Status[message["data"].decode("utf-8").upper()]
                 if asyncio.iscoroutinefunction(callback):
                     stop = await callback(job_key, status)

--- a/saq/types.py
+++ b/saq/types.py
@@ -1,6 +1,7 @@
 """
 Types
 """
+
 from __future__ import annotations
 
 import typing as t

--- a/saq/utils.py
+++ b/saq/utils.py
@@ -1,6 +1,7 @@
 """
 Utils
 """
+
 from __future__ import annotations
 
 import time

--- a/saq/web/starlette.py
+++ b/saq/web/starlette.py
@@ -1,6 +1,7 @@
 """
 Starlette/FastAPI/ASGI
 """
+
 from __future__ import annotations
 
 import os

--- a/saq/worker.py
+++ b/saq/worker.py
@@ -1,6 +1,7 @@
 """
 Workers
 """
+
 from __future__ import annotations
 
 import asyncio

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -401,3 +401,7 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
         self.queue.unregister_before_enqueue(callback)
         await self.enqueue("test")
         self.assertIsNone(called_with_job)
+
+    async def test_job_key(self) -> None:
+        self.assertEqual("a", self.queue.job_key_from_id(self.queue.job_id("a")))
+        self.assertEqual("a:b", self.queue.job_key_from_id(self.queue.job_id("a:b")))


### PR DESCRIPTION
Old code doesn't allow colons in job keys