### PR TITLE
Handle redis version being a float

### DIFF
--- a/saq/queue.py
+++ b/saq/queue.py
@@ -161,7 +161,7 @@ class Queue:
     async def version(self) -> VersionTuple:
         if self._version is None:
             info = await self.redis.info()
-            self._version = tuple(int(i) for i in info["redis_version"].split("."))
+            self._version = tuple(int(i) for i in str(info["redis_version"]).split("."))
         return self._version
 
     async def info(


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/08f94b6b-1404-4e60-b98b-f9f9ce975739)
Aws elasticache redis doesnt vibe with current version of SAQ