### PR TITLE
Include queue package when building

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     license="MIT",
     packages=[
         "saq",
+        "saq.queue",
         "saq.web",
     ],
     include_package_data=True,


### PR DESCRIPTION
Fixes #137 

The queue package was not being included when building the wheel. This PR now includes it.