### PR TITLE
Fix: Default queue is always created during health check

### DIFF
--- a/saq/worker.py
+++ b/saq/worker.py
@@ -387,5 +387,5 @@ async def async_check_health(queue: Queue) -> int:
 def check_health(settings: str) -> int:
     settings_dict = import_settings(settings)
     loop = asyncio.new_event_loop()
-    queue = settings_dict.get("queue", Queue.from_url("redis://localhost"))
+    queue = settings_dict.get("queue") or Queue.from_url("redis://localhost")
     return loop.run_until_complete(async_check_health(queue))


### PR DESCRIPTION
Even if the health check is for a Postgres queue, a Redis queue is always created.