### PR TITLE
Fix cronjob inability to pass kwargs to the function

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ SAQ is heavily inspired by [ARQ](https://github.com/samuelcolvin/arq) but has se
 python -m venv env
 source env/bin/activate
 pip install -e ".[dev,web]"
-docker run -p 6379:6379 redis
+docker run -d -p 6379:6379 redis
+docker run -d -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust postgres
 ./run_checks.sh
 ```

--- a/saq/job.py
+++ b/saq/job.py
@@ -66,6 +66,7 @@ class CronJob:
     heartbeat: int | None = None
     retries: int | None = None
     ttl: int | None = None
+    kwargs: dict[str, t.Any] | None = None
 
 
 @dataclasses.dataclass

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -41,8 +41,8 @@ async def sleeper(_ctx: Context, sleep: float = 0.1) -> dict[str, t.Any]:
     return {"a": 1, "b": []}
 
 
-async def cron(_ctx: Context) -> int:
-    return 1
+async def cron(_ctx: Context, *, param: int) -> int:
+    return param
 
 
 async def error(_ctx: Context) -> t.NoReturn:
@@ -277,7 +277,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         worker = Worker(
             self.queue,
             functions=functions,
-            cron_jobs=[CronJob(cron, cron="* * * * *")],
+            cron_jobs=[CronJob(cron, cron="* * * * *", kwargs={"param": 1})],
         )
         self.assertEqual(await self.queue.count("queued"), 0)
         self.assertEqual(await self.queue.count("incomplete"), 0)


### PR DESCRIPTION
Fix a bug where cronjob creation could not accept a kwargs parameter as described in the documentation