### PR TITLE
Fix: Listen forever if timeout param is 0 (postgres)

### DIFF
--- a/saq/queue/postgres.py
+++ b/saq/queue/postgres.py
@@ -355,7 +355,11 @@ class PostgresQueue(Queue):
             for key in job_keys:
                 await conn.execute(SQL("LISTEN {}").format(Identifier(key)))
             await conn.commit()
-            await asyncio.wait_for(_listen(conn.notifies()), timeout)
+
+            if timeout:
+                await asyncio.wait_for(_listen(conn.notifies()), timeout)
+            else:
+                await _listen(conn.notifies())
 
     async def notify(self, job: Job, connection: AsyncConnection | None = None) -> None:
         payload = json.dumps({"key": job.key, "status": job.status})


### PR DESCRIPTION
Right now, timeout of 0 times out immediately, which is wrong.