### PR TITLE
Chore: Introduce queue upkeep

### DIFF
--- a/saq/queue/base.py
+++ b/saq/queue/base.py
@@ -68,6 +68,7 @@ class Queue(ABC):
         self._dump = dump or json.dumps
         self._load = load or json.loads
         self._before_enqueues: dict[int, BeforeEnqueueType] = {}
+        self.tasks: set[asyncio.Task[t.Any]] = set()
 
     def job_id(self, job_key: str) -> str:
         return job_key
@@ -168,6 +169,9 @@ class Queue(ABC):
             return PostgresQueue.from_url(url, **kwargs)
 
         raise ValueError("URL is not valid")
+
+    async def upkeep(self) -> set[asyncio.Task[None]]:
+        return set()
 
     async def connect(self) -> None:
         pass

--- a/saq/queue/base.py
+++ b/saq/queue/base.py
@@ -170,9 +170,8 @@ class Queue(ABC):
 
         raise ValueError("URL is not valid")
 
-    async def upkeep(self) -> set[asyncio.Task[None]]:
+    async def upkeep(self) -> None:
         """Start various upkeep tasks async."""
-        return set()
 
     async def stop(self) -> None:
         """Stop the queue and cleanup."""

--- a/saq/queue/postgres.py
+++ b/saq/queue/postgres.py
@@ -120,14 +120,13 @@ class PostgresQueue(Queue):
                     )
                 )
 
-    async def upkeep(self) -> set[asyncio.Task[None]]:
+    async def upkeep(self) -> None:
         await self.init_db()
 
         self.tasks.add(asyncio.create_task(self.wait_for_job()))
         self.tasks.add(asyncio.create_task(self.listen_for_enqueues()))
         if self.poll_interval > 0:
             self.tasks.add(asyncio.create_task(self.dequeue_timer(self.poll_interval)))
-        return self.tasks
 
     async def connect(self) -> None:
         if self.connection:

--- a/saq/queue/postgres.py
+++ b/saq/queue/postgres.py
@@ -110,7 +110,24 @@ class PostgresQueue(Queue):
         self.connection_lock = asyncio.Lock()
         self.released: list[str] = []
         self.has_sweep_lock = False
-        self.tasks: list[asyncio.Task] = []
+
+    async def init_db(self) -> None:
+        async with self.pool.connection() as conn, conn.cursor() as cursor:
+            for statement in DDL_STATEMENTS:
+                await cursor.execute(
+                    SQL(statement).format(
+                        jobs_table=self.jobs_table, stats_table=self.stats_table
+                    )
+                )
+
+    async def upkeep(self) -> set[asyncio.Task[None]]:
+        await self.init_db()
+
+        self.tasks.add(asyncio.create_task(self.wait_for_job()))
+        self.tasks.add(asyncio.create_task(self.listen_for_enqueues()))
+        if self.poll_interval > 0:
+            self.tasks.add(asyncio.create_task(self.dequeue_timer(self.poll_interval)))
+        return self.tasks
 
     async def connect(self) -> None:
         if self.connection:
@@ -119,22 +136,8 @@ class PostgresQueue(Queue):
 
         await self.pool.open()
         await self.pool.resize(min_size=self.min_size, max_size=self.max_size)
-        async with self.pool.connection() as conn, conn.cursor() as cursor:
-            for statement in DDL_STATEMENTS:
-                await cursor.execute(
-                    SQL(statement).format(
-                        jobs_table=self.jobs_table, stats_table=self.stats_table
-                    )
-                )
         # Reserve a connection for dequeue and advisory locks
         self.connection = await self.pool.getconn()
-
-        self.tasks.append(asyncio.create_task(self.wait_for_job()))
-        self.tasks.append(asyncio.create_task(self.listen_for_enqueues()))
-        if self.poll_interval > 0:
-            self.tasks.append(
-                asyncio.create_task(self.dequeue_timer(self.poll_interval))
-            )
 
     def serialize(self, job: Job) -> bytes | str:
         """Ensure serialized job is in bytes because the job column is of type BYTEA."""
@@ -144,17 +147,12 @@ class PostgresQueue(Queue):
         return serialized
 
     async def disconnect(self) -> None:
-        if self.connection:
-            await self.connection.cancel_safe()
-            await self.pool.putconn(self.connection)
-            self.connection = None
+        async with self.connection_lock:
+            if self.connection:
+                await self.connection.cancel_safe()
+                await self.pool.putconn(self.connection)
+                self.connection = None
         await self.pool.close()
-        for task in self.tasks:
-            task.cancel()
-        try:
-            await asyncio.gather(*self.tasks, return_exceptions=True)
-        except asyncio.exceptions.CancelledError:
-            pass
         self.has_sweep_lock = False
 
     async def info(

--- a/saq/utils.py
+++ b/saq/utils.py
@@ -4,9 +4,14 @@ Utils
 
 from __future__ import annotations
 
+import asyncio
 import time
+import typing as t
 import uuid
 from random import random
+
+if t.TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 def now() -> int:
@@ -53,3 +58,10 @@ def exponential_backoff(
     if jitter:
         backoff = backoff * random()
     return backoff
+
+
+async def cancel_tasks(tasks: Iterable[asyncio.Task]) -> None:
+    """Cancel tasks and wait for all of them to finish"""
+    for task in tasks:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -33,10 +33,7 @@ async def create_postgres_queue(**kwargs: t.Any) -> PostgresQueue:
 async def cleanup_queue(queue: Queue) -> None:
     if isinstance(queue, RedisQueue):
         await queue.redis.flushdb()
-    for task in queue.tasks:
-        task.cancel()
-    await asyncio.gather(*queue.tasks, return_exceptions=True)
-    queue.tasks.clear()
+    await queue.stop()
     await queue.disconnect()
 
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -176,7 +176,7 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
 
     async def test_retry_delay(self) -> None:
         # Let's first verify how things work without a retry delay
-        worker = Worker(self.queue, functions=functions, dequeue_timeout=0.01)
+        worker = Worker(self.queue, functions=functions, dequeue_timeout=0.1)
         job = await self.enqueue("error", retries=2)
         await worker.process()
         await job.refresh()
@@ -440,12 +440,14 @@ class TestPostgresQueue(TestQueue):
         await super().asyncTearDown()
         await teardown_postgres()
 
+    @unittest.skip("Not implemented")
     async def test_job_key(self) -> None:
-        self.skipTest("Not implemented")
+        pass
 
+    @unittest.skip("Not implemented")
     @mock.patch("saq.utils.time")
     async def test_schedule(self, mock_time: MagicMock) -> None:
-        self.skipTest("Not implemented")
+        pass
 
     async def test_batch(self) -> None:
         with contextlib.suppress(ValueError):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -345,8 +345,9 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
             ctx_var.set("123")
 
         self.worker.before_process = before_process
-        asyncio.create_task(self.worker.start())
+        task = asyncio.create_task(self.worker.start())
         self.assertEqual(await self.queue.apply("sync_echo_ctx"), "123")
+        task.cancel()
 
     async def test_propagation(self) -> None:
         async def before_process(ctx: Context) -> None:


### PR DESCRIPTION
This PR introduces queue specific upkeep tasks. For the Postgres queue, this helps decouple opening the queue's connection pool and various upkeep tasks like the dequeue timer and enqueue listener.