### PR TITLE
Fix: Set psycopg minimum version to 3.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
             "aiohttp_basicauth",
             "coverage",
             "mypy",
-            "psycopg[pool]",
+            "psycopg[pool]>=3.2.0",
             "pre-commit",
             "redis>=4.2,<6.0",
             "ruff",


### PR DESCRIPTION
Some features, like AsyncConnection.cancel_safe(), is only available since psycopg v3.2.0.