### PR TITLE
Fix: Do not expire jobs when aborting

### DIFF
--- a/saq/queue/postgres.py
+++ b/saq/queue/postgres.py
@@ -365,16 +365,14 @@ class PostgresQueue(Queue):
     async def update(
         self,
         job: Job,
-        status: Status | None = None,
-        scheduled: int | None = None,
-        expire_at: float | None = -1,
         connection: AsyncConnection | None = None,
+        expire_at: float | None = -1,
+        **kwargs: t.Any,
     ) -> None:
-        if status:
-            job.status = status
-        if scheduled:
-            job.scheduled = scheduled
         job.touched = now()
+
+        for k, v in kwargs.items():
+            setattr(job, k, v)
 
         async with self.nullcontext(connection) if connection else self.pool.connection() as conn:
             await conn.execute(

--- a/saq/queue/postgres.py
+++ b/saq/queue/postgres.py
@@ -486,7 +486,7 @@ class PostgresQueue(Queue):
 
     async def abort(self, job: Job, error: str, ttl: float = 5) -> None:
         job.error = error
-        await self.update(job, status=Status.ABORTING, expire_at=int(seconds(now()) + ttl) + 1)
+        await self.update(job, status=Status.ABORTING)
 
     async def dequeue(self, timeout: float = 0) -> Job | None:
         """Wait on `self.cond` to dequeue.


### PR DESCRIPTION
Jobs should not have an expiration while it is aborting. Redis has a TTL on abort_id, but Postgres doesn't use abort_id. Postgres won't re-enqueue an aborting job by checking the job's status.