### PR TITLE
Fix: Handle aborting a job before it has started processing in Postgres

### DIFF
--- a/saq/queue/base.py
+++ b/saq/queue/base.py
@@ -228,6 +228,7 @@ class Queue(ABC):
         *,
         result: t.Any = None,
         error: str | None = None,
+        **kwargs: t.Any,
     ) -> None:
         job.status = status
         job.result = result
@@ -237,7 +238,7 @@ class Queue(ABC):
         if status == Status.COMPLETE:
             job.progress = 1.0
 
-        await self._finish(job=job, status=status, result=result, error=error)
+        await self._finish(job=job, status=status, result=result, error=error, **kwargs)
         logger.info("Finished %s", job.info(logger.isEnabledFor(logging.DEBUG)))
 
         if status == Status.COMPLETE:

--- a/saq/queue/postgres.py
+++ b/saq/queue/postgres.py
@@ -485,26 +485,9 @@ class PostgresQueue(Queue):
     async def abort(self, job: Job, error: str, ttl: float = 5) -> None:
         job.error = error
 
-        async with self.pool.connection() as conn, conn.cursor() as cursor:
-            await cursor.execute(
-                SQL(
-                    dedent(
-                        """
-                        SELECT status
-                        FROM {jobs_table}
-                        WHERE key = %(key)s
-                        FOR UPDATE
-                        """
-                    )
-                ).format(
-                    jobs_table=self.jobs_table,
-                ),
-                {
-                    "key": job.key,
-                },
-            )
-            result = await cursor.fetchone()
-            if result == (Status.QUEUED,):
+        async with self.pool.connection() as conn:
+            status = await self.get_job_status(job.key, for_update=True, connection=conn)
+            if status == Status.QUEUED:
                 await self.finish(job, Status.ABORTED, error=error, connection=conn)
             else:
                 await self.update(job, status=Status.ABORTING, connection=conn)
@@ -602,6 +585,37 @@ class PostgresQueue(Queue):
             async for _ in gen:
                 async with self.cond:
                     self.cond.notify(1)
+
+    async def get_job_status(
+        self,
+        key: str,
+        for_update: bool = False,
+        connection: AsyncConnection | None = None,
+    ) -> Status:
+        async with self.nullcontext(
+            connection
+        ) if connection else self.pool.connection() as conn, conn.cursor() as cursor:
+            await cursor.execute(
+                SQL(
+                    dedent(
+                        """
+                        SELECT status
+                        FROM {jobs_table}
+                        WHERE key = %(key)s
+                        {for_update}
+                        """
+                    )
+                ).format(
+                    jobs_table=self.jobs_table,
+                    for_update=SQL("FOR UPDATE" if for_update else ""),
+                ),
+                {
+                    "key": key,
+                },
+            )
+            result = await cursor.fetchone()
+            assert result
+            return result[0]
 
     async def _retry(self, job: Job, error: str | None) -> None:
         next_retry_delay = job.next_retry_delay()

--- a/saq/queue/postgres.py
+++ b/saq/queue/postgres.py
@@ -483,14 +483,12 @@ class PostgresQueue(Queue):
                     break
 
     async def abort(self, job: Job, error: str, ttl: float = 5) -> None:
-        job.error = error
-
         async with self.pool.connection() as conn:
             status = await self.get_job_status(job.key, for_update=True, connection=conn)
             if status == Status.QUEUED:
                 await self.finish(job, Status.ABORTED, error=error, connection=conn)
             else:
-                await self.update(job, status=Status.ABORTING, connection=conn)
+                await self.update(job, status=Status.ABORTING, error=error, connection=conn)
 
     async def dequeue(self, timeout: float = 0) -> Job | None:
         """Wait on `self.cond` to dequeue.

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -461,14 +461,6 @@ class TestPostgresQueue(TestQueue):
     async def test_schedule(self, mock_time: MagicMock) -> None:
         pass
 
-    async def test_batch(self) -> None:
-        with contextlib.suppress(ValueError):
-            async with self.queue.batch():
-                job = await self.enqueue("echo", a=1)
-                raise ValueError()
-
-        self.assertEqual(job.status, Status.ABORTING)
-
     async def test_enqueue_dup(self) -> None:
         job = await self.enqueue("test", key="1")
         self.assertEqual(job.id, "1")

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -452,22 +452,6 @@ class TestPostgresQueue(TestQueue):
         await super().asyncTearDown()
         await teardown_postgres()
 
-    async def get_job_status(self, key: str) -> Status:
-        async with self.queue.pool.connection() as conn, conn.cursor() as cursor:
-            await cursor.execute(
-                SQL(
-                    """
-                    SELECT status
-                    FROM {}
-                    WHERE key = %s
-                    """
-                ).format(self.queue.jobs_table),
-                (key,),
-            )
-            result = await cursor.fetchone()
-            assert result
-            return result[0]
-
     @unittest.skip("Not implemented")
     async def test_job_key(self) -> None:
         pass
@@ -492,7 +476,7 @@ class TestPostgresQueue(TestQueue):
         self.assertEqual(await self.count("incomplete"), 0)
         await job.refresh()
         self.assertEqual(job.status, Status.ABORTED)
-        self.assertEqual(await self.get_job_status(job.key), Status.ABORTED)
+        self.assertEqual(await self.queue.get_job_status(job.key), Status.ABORTED)
 
         job = await self.enqueue("test", retries=2)
         await self.dequeue()
@@ -503,7 +487,7 @@ class TestPostgresQueue(TestQueue):
         self.assertEqual(await self.count("queued"), 0)
         self.assertEqual(await self.count("incomplete"), 0)
         self.assertEqual(await self.count("active"), 0)
-        self.assertEqual(await self.get_job_status(job.key), Status.ABORTING)
+        self.assertEqual(await self.queue.get_job_status(job.key), Status.ABORTING)
 
     @mock.patch("saq.utils.time")
     async def test_sweep(self, mock_time: MagicMock) -> None:


### PR DESCRIPTION
If a job hasn't been dequeued yet and it is aborted, its status should be updated to `aborted`.