### PR TITLE
fix: postgres sweeping doesn't need to update job state

### DIFF
--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -512,7 +512,6 @@ class TestPostgresQueue(TestQueue):
             {
                 job1.key,
                 job2.key,
-                job3.key,
             },
         )
         await job1.refresh()
@@ -521,7 +520,7 @@ class TestPostgresQueue(TestQueue):
         self.assertEqual(job1.status, Status.ABORTED)
         self.assertEqual(job2.status, Status.QUEUED)
         self.assertEqual(job3.status, Status.QUEUED)
-        self.assertEqual(await self.count("active"), 2)
+        self.assertEqual(await self.count("active"), 3)
 
     @mock.patch("saq.utils.time")
     async def test_sweep_stuck(self, mock_time: MagicMock) -> None:


### PR DESCRIPTION
the sweeper atomically changes the job table state to be active, when a job gets processed, at that point it will be updated to active. it won't get swept if there's an advisory lock. if the lock is lost and the job never got picked up, then it will be considered stuck and swept.