### PR TITLE
feat!: add metadata for workers

### DIFF
--- a/saq/job.py
+++ b/saq/job.py
@@ -219,7 +219,7 @@ class Job:
         Returns the duration of the job given kind.
 
         Args:
-            Kind (DurationKind): The kind of duration type, can be:
+            kind (DurationKind): The kind of duration type, can be:
                 * `process` (how long it took to process)
                 * `start` (how long it took to start)
                 * `total`

--- a/saq/queue/base.py
+++ b/saq/queue/base.py
@@ -136,6 +136,12 @@ class Queue(ABC):
         pass
 
     @abstractmethod
+    async def write_worker_metadata(
+        self, queue_key: str, ip_address: str, metadata: t.Optional[dict], ttl: int
+    ) -> None:
+        pass
+
+    @abstractmethod
     async def _retry(self, job: Job, error: str | None) -> None:
         pass
 

--- a/saq/queue/http.py
+++ b/saq/queue/http.py
@@ -105,6 +105,14 @@ class HttpProxy:
             if kind == "write_stats":
                 await self.queue.write_stats(req["stats"], ttl=req["ttl"])
                 return None
+            if kind == "write_worker_metadata":
+                await self.queue.write_worker_metadata(
+                    metadata=req["metadata"],
+                    ttl=req["ttl"],
+                    ip_address=req["ip_address"],
+                    queue_key=req["queue_key"],
+                )
+                return None
         raise ValueError(f"Invalid request {body}")
 
 
@@ -208,6 +216,17 @@ class HttpQueue(Queue):
 
     async def write_stats(self, stats: QueueStats, ttl: int) -> None:
         await self._send("write_stats", stats=stats, ttl=ttl)
+
+    async def write_worker_metadata(
+        self, queue_key: str, ip_address: str, metadata: t.Optional[dict], ttl: int
+    ) -> None:
+        await self._send(
+            "write_worker_metadata",
+            metadata=metadata,
+            ttl=ttl,
+            ip_address=ip_address,
+            queue_key=queue_key,
+        )
 
     async def info(self, jobs: bool = False, offset: int = 0, limit: int = 10) -> QueueInfo:
         return json.loads(await self._send("info", jobs=jobs, offset=offset, limit=limit))

--- a/saq/queue/postgres_ddl.py
+++ b/saq/queue/postgres_ddl.py
@@ -20,7 +20,18 @@ CREATE_STATS_TABLE = """
 CREATE TABLE IF NOT EXISTS {stats_table} (
     worker_id TEXT PRIMARY KEY,
     stats JSONB,
+    metadata JSONB,
     expire_at BIGINT
+);
+"""
+
+CREATE_WORKER_METADATA_TABLE = """
+CREATE TABLE IF NOT EXISTS {worker_metadata_table} (
+    worker_id TEXT PRIMARY KEY,
+    queue_key TEXT NOT NULL,
+    expire_at BIGINT NOT NULL,
+    ip_address TEXT,
+    metadata JSONB 
 );
 """
 
@@ -28,4 +39,5 @@ DDL_STATEMENTS = [
     CREATE_JOBS_TABLE,
     CREATE_JOBS_DEQUEUE_INDEX,
     CREATE_STATS_TABLE,
+    CREATE_WORKER_METADATA_TABLE,
 ]

--- a/saq/queue/redis.py
+++ b/saq/queue/redis.py
@@ -40,6 +40,7 @@ if t.TYPE_CHECKING:
         QueueInfo,
         QueueStats,
         VersionTuple,
+        WorkerInfo,
     )
 
 ID_PREFIX = "saq:job:"
@@ -133,12 +134,29 @@ class RedisQueue(Queue):
         worker_stats = await self.redis.mget(
             self.namespace(f"stats:{worker_uuid}") for worker_uuid in worker_uuids
         )
-
-        worker_info = {}
-        for worker_uuid, stats in zip(worker_uuids, worker_stats):
+        worker_metadata = await self.redis.mget(
+            self.namespace(f"metadata:{worker_uuid}") for worker_uuid in worker_uuids
+        )
+        workers: dict[str, WorkerInfo] = {}
+        worker_metadata_dict = dict(zip(worker_uuids, worker_metadata))
+        worker_stats_dict = dict(zip(worker_uuids, worker_stats))
+        for worker in worker_uuids:
+            workers[worker] = {
+                "queue_key": None,
+                "ip_address": None,
+                "stats": {},
+                "metadata": None,
+            }
+            metadata = worker_metadata_dict[worker]
+            if metadata:
+                metadata_obj = json.loads(metadata)
+                workers[worker]["metadata"] = metadata_obj["metadata"]
+                workers[worker]["ip_address"] = metadata_obj["ip_address"]
+                workers[worker]["queue_key"] = metadata_obj["queue_key"]
+            stats = worker_stats_dict[worker]
             if stats:
                 stats_obj = json.loads(stats)
-                worker_info[worker_uuid] = stats_obj
+                workers[worker]["stats"] = stats_obj
 
         queued = await self.count("queued")
         active = await self.count("active")
@@ -166,7 +184,7 @@ class RedisQueue(Queue):
             job_info = []
 
         return {
-            "workers": worker_info,
+            "workers": workers,
             "name": self.name,
             "queued": queued,
             "active": active,
@@ -406,6 +424,14 @@ class RedisQueue(Queue):
                 .expire(self._stats, ttl)
                 .execute()
             )
+
+    async def write_worker_metadata(
+        self, queue_key: str, ip_address: str, metadata: t.Optional[dict], ttl: int
+    ) -> None:
+        async with self.redis.pipeline(transaction=True) as pipe:
+            key = self.namespace(f"metadata:{self.uuid}")
+            metadata = {"queue_key": queue_key, "ip_address": ip_address, "metadata": metadata}
+            await pipe.setex(key, ttl, json.dumps(metadata)).expire(key, ttl).execute()
 
     async def _retry(self, job: Job, error: str | None) -> None:
         job_id = job.id

--- a/saq/types.py
+++ b/saq/types.py
@@ -45,12 +45,23 @@ class JobTaskContext(t.TypedDict, total=False):
     "If this task has been aborted, this is the reason"
 
 
+class WorkerInfo(t.TypedDict):
+    """
+    Worker Info
+    """
+
+    queue_key: t.Optional[str]
+    ip_address: t.Optional[str]
+    stats: dict[str, t.Any]
+    metadata: t.Optional[dict[str, t.Any]]
+
+
 class QueueInfo(t.TypedDict):
     """
     Queue Info
     """
 
-    workers: dict[str, dict[str, t.Any]]
+    workers: dict[str, WorkerInfo]
     "Worker information"
     name: str
     "Queue name"
@@ -93,6 +104,8 @@ class TimersDict(t.TypedDict):
     "How often to clean up stuck jobs in seconds (default 60)"
     abort: int
     "How often to check if a job is aborted in seconds (default 1)"
+    metadata: int
+    "How often to write worker metadata in seconds (default 60)"
 
 
 class PartialTimersDict(TimersDict, total=False):


### PR DESCRIPTION
- add a table to store optional metadata for workers such that workers can report things like IP address and other metadata
- add an optional ability for workers to add metadata to that table

**Breaking** 

- in info object, moved stats for a particular worker under stats, which sits side by side now with metadata than straight inside a worker

{ "worker_id": ...stats, ... } -> { "worker_id": { "stats": ...stats, "metadata": ...metadata }, ... }