### PR TITLE
fix: http workers pass their own id

### DIFF
--- a/saq/queue/base.py
+++ b/saq/queue/base.py
@@ -18,7 +18,7 @@ from saq.job import (
     Status,
     get_default_job_key,
 )
-from saq.utils import now, uuid1
+from saq.utils import now
 
 if t.TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterable, Sequence
@@ -59,7 +59,6 @@ class Queue(ABC):
         load: LoadType | None,
     ) -> None:
         self.name = name
-        self.uuid: str = uuid1()
         self.started: int = now()
         self.complete = 0
         self.failed = 0
@@ -195,7 +194,16 @@ class Queue(ABC):
             raise ValueError(f"Job {job_dict} fetched by wrong queue: {self.name}")
         return Job(**job_dict, queue=self)
 
-    async def stats(self, ttl: int = 60) -> QueueStats:
+    async def stats(self, worker_id: str, ttl: int = 60) -> QueueStats:
+        """
+        Method to be used by workers to update stats.
+
+        Args:
+            worker_id: The worker id.
+            ttl: Time stats are valid for in seconds.
+
+        Returns: The stats.
+        """
         stats: QueueStats = {
             "complete": self.complete,
             "failed": self.failed,
@@ -203,7 +211,7 @@ class Queue(ABC):
             "aborted": self.aborted,
             "uptime": now() - self.started,
         }
-        await self.write_stats(self.uuid, stats, ttl)
+        await self.write_stats(worker_id, stats, ttl)
         return stats
 
     def register_before_enqueue(self, callback: BeforeEnqueueType) -> None:

--- a/saq/queue/base.py
+++ b/saq/queue/base.py
@@ -30,7 +30,7 @@ if t.TYPE_CHECKING:
         DumpType,
         LoadType,
         QueueInfo,
-        QueueStats,
+        WorkerStats,
     )
 
 
@@ -131,7 +131,7 @@ class Queue(ABC):
         await job.finish(Status.ABORTED, error=job.error)
 
     @abstractmethod
-    async def write_stats(self, worker_id: str, stats: QueueStats, ttl: int) -> None:
+    async def write_stats(self, worker_id: str, stats: WorkerStats, ttl: int) -> None:
         """
         Returns & updates stats on the queue.
 
@@ -194,7 +194,7 @@ class Queue(ABC):
             raise ValueError(f"Job {job_dict} fetched by wrong queue: {self.name}")
         return Job(**job_dict, queue=self)
 
-    async def stats(self, worker_id: str, ttl: int = 60) -> QueueStats:
+    async def stats(self, worker_id: str, ttl: int = 60) -> WorkerStats:
         """
         Method to be used by workers to update stats.
 
@@ -204,7 +204,7 @@ class Queue(ABC):
 
         Returns: The stats.
         """
-        stats: QueueStats = {
+        stats: WorkerStats = {
             "complete": self.complete,
             "failed": self.failed,
             "retried": self.retried,

--- a/saq/queue/base.py
+++ b/saq/queue/base.py
@@ -132,7 +132,16 @@ class Queue(ABC):
         await job.finish(Status.ABORTED, error=job.error)
 
     @abstractmethod
-    async def write_stats(self, stats: QueueStats, ttl: int) -> None:
+    async def write_stats(self, worker_id: str, stats: QueueStats, ttl: int) -> None:
+        """
+        Returns & updates stats on the queue.
+
+        Args:
+            worker_id: The worker id, passed in rather than taken from the queue instance to ensure that the stats
+                are attributed to the worker and not the queue instance in the proxy server.
+            stats: The stats to write.
+            ttl: The time-to-live in seconds.
+        """
         pass
 
     @abstractmethod
@@ -194,8 +203,7 @@ class Queue(ABC):
             "aborted": self.aborted,
             "uptime": now() - self.started,
         }
-
-        await self.write_stats(stats, ttl)
+        await self.write_stats(self.uuid, stats, ttl)
         return stats
 
     def register_before_enqueue(self, callback: BeforeEnqueueType) -> None:

--- a/saq/queue/http.py
+++ b/saq/queue/http.py
@@ -103,7 +103,9 @@ class HttpProxy:
                     )
                 )
             if kind == "write_stats":
-                await self.queue.write_stats(req["stats"], ttl=req["ttl"])
+                await self.queue.write_stats(
+                    worker_id=req["worker_id"], stats=req["stats"], ttl=req["ttl"]
+                )
                 return None
         raise ValueError(f"Invalid request {body}")
 
@@ -206,8 +208,8 @@ class HttpQueue(Queue):
     async def dequeue(self, timeout: float = 0) -> Job | None:
         return self.deserialize(await self._send("dequeue", timeout=timeout))
 
-    async def write_stats(self, stats: QueueStats, ttl: int) -> None:
-        await self._send("write_stats", stats=stats, ttl=ttl)
+    async def write_stats(self, worker_id: str, stats: QueueStats, ttl: int) -> None:
+        await self._send("write_stats", worker_id=worker_id, stats=stats, ttl=ttl)
 
     async def info(self, jobs: bool = False, offset: int = 0, limit: int = 10) -> QueueInfo:
         return json.loads(await self._send("info", jobs=jobs, offset=offset, limit=limit))

--- a/saq/queue/http.py
+++ b/saq/queue/http.py
@@ -18,7 +18,7 @@ if t.TYPE_CHECKING:
     from saq.types import (
         CountKind,
         QueueInfo,
-        QueueStats,
+        WorkerStats,
     )
 
 try:
@@ -208,7 +208,7 @@ class HttpQueue(Queue):
     async def dequeue(self, timeout: float = 0) -> Job | None:
         return self.deserialize(await self._send("dequeue", timeout=timeout))
 
-    async def write_stats(self, worker_id: str, stats: QueueStats, ttl: int) -> None:
+    async def write_stats(self, worker_id: str, stats: WorkerStats, ttl: int) -> None:
         await self._send("write_stats", worker_id=worker_id, stats=stats, ttl=ttl)
 
     async def info(self, jobs: bool = False, offset: int = 0, limit: int = 10) -> QueueInfo:

--- a/saq/queue/postgres.py
+++ b/saq/queue/postgres.py
@@ -670,7 +670,7 @@ class PostgresQueue(Queue):
         logger.info("Enqueuing %s", job.info(logger.isEnabledFor(logging.DEBUG)))
         return job
 
-    async def write_stats(self, stats: QueueStats, ttl: int) -> None:
+    async def write_stats(self, worker_id: str, stats: QueueStats, ttl: int) -> None:
         async with self.pool.connection() as conn:
             await conn.execute(
                 SQL(
@@ -684,7 +684,7 @@ class PostgresQueue(Queue):
                     )
                 ).format(stats_table=self.stats_table),
                 {
-                    "worker_id": self.uuid,
+                    "worker_id": worker_id,
                     "stats": json.dumps(stats),
                     "ttl": ttl,
                 },

--- a/saq/queue/postgres.py
+++ b/saq/queue/postgres.py
@@ -32,7 +32,7 @@ if t.TYPE_CHECKING:
         DumpType,
         LoadType,
         QueueInfo,
-        QueueStats,
+        WorkerStats,
     )
 
 try:
@@ -670,7 +670,7 @@ class PostgresQueue(Queue):
         logger.info("Enqueuing %s", job.info(logger.isEnabledFor(logging.DEBUG)))
         return job
 
-    async def write_stats(self, worker_id: str, stats: QueueStats, ttl: int) -> None:
+    async def write_stats(self, worker_id: str, stats: WorkerStats, ttl: int) -> None:
         async with self.pool.connection() as conn:
             await conn.execute(
                 SQL(

--- a/saq/queue/redis.py
+++ b/saq/queue/redis.py
@@ -38,7 +38,7 @@ if t.TYPE_CHECKING:
         ListenCallback,
         LoadType,
         QueueInfo,
-        QueueStats,
+        WorkerStats,
         VersionTuple,
     )
 
@@ -389,7 +389,7 @@ class RedisQueue(Queue):
         await self.redis.delete(job.abort_id)
         await super().finish_abort(job)
 
-    async def write_stats(self, worker_id: str, stats: QueueStats, ttl: int) -> None:
+    async def write_stats(self, worker_id: str, stats: WorkerStats, ttl: int) -> None:
         current = now()
         async with self.redis.pipeline(transaction=True) as pipe:
             key = self.namespace(f"stats:{worker_id}")

--- a/saq/queue/redis.py
+++ b/saq/queue/redis.py
@@ -389,16 +389,10 @@ class RedisQueue(Queue):
         await self.redis.delete(job.abort_id)
         await super().finish_abort(job)
 
-    async def write_stats(self, stats: QueueStats, ttl: int) -> None:
-        """
-        Returns & updates stats on the queue
-
-        Args:
-            ttl: Time-to-live of stats saved in Redis
-        """
+    async def write_stats(self, worker_id: str, stats: QueueStats, ttl: int) -> None:
         current = now()
         async with self.redis.pipeline(transaction=True) as pipe:
-            key = self.namespace(f"stats:{self.uuid}")
+            key = self.namespace(f"stats:{worker_id}")
             await (
                 pipe.setex(key, ttl, json.dumps(stats))
                 .zremrangebyscore(self._stats, 0, current)

--- a/saq/types.py
+++ b/saq/types.py
@@ -63,9 +63,9 @@ class QueueInfo(t.TypedDict):
     "A truncated list containing the jobs that are scheduled to execute soonest"
 
 
-class QueueStats(t.TypedDict):
+class WorkerStats(t.TypedDict):
     """
-    Queue Stats, could also be used for Worker Stats
+    Worker Stats
     """
 
     complete: int

--- a/saq/types.py
+++ b/saq/types.py
@@ -65,7 +65,7 @@ class QueueInfo(t.TypedDict):
 
 class QueueStats(t.TypedDict):
     """
-    Queue Stats
+    Queue Stats, could also be used for Worker Stats
     """
 
     complete: int

--- a/saq/worker.py
+++ b/saq/worker.py
@@ -36,7 +36,7 @@ if t.TYPE_CHECKING:
         ReceivesContext,
         SettingsDict,
         TimersDict,
-        QueueStats,
+        WorkerStats,
     )
 
 
@@ -118,7 +118,7 @@ class Worker:
         self.burst_jobs_processed = 0
         self.burst_jobs_processed_lock = threading.Lock()
         self.burst_condition_met = False
-        self.id = id if id is not None else uuid1()
+        self.id = uuid1() if id is None else id
 
         if self.burst:
             if self.dequeue_timeout <= 0:
@@ -155,7 +155,6 @@ class Worker:
         """Start processing jobs and upkeep tasks."""
         logger.info("Worker starting: %s", repr(self.queue))
         logger.debug("Registered functions:\n%s", "\n".join(f"  {key}" for key in self.functions))
-        await self.stats()
 
         try:
             self.event = asyncio.Event()
@@ -218,7 +217,7 @@ class Worker:
         if scheduled:
             logger.info("Scheduled %s", scheduled)
 
-    async def stats(self, ttl: int = 60) -> QueueStats:
+    async def stats(self, ttl: int = 60) -> WorkerStats:
         return await self.queue.stats(self.id, ttl)
 
     async def upkeep(self) -> list[Task[None]]:

--- a/saq/worker.py
+++ b/saq/worker.py
@@ -19,7 +19,7 @@ from croniter import croniter
 
 from saq.job import Status
 from saq.queue import Queue
-from saq.utils import cancel_tasks, millis, now, now_seconds
+from saq.utils import cancel_tasks, millis, now, now_seconds, uuid1
 
 if t.TYPE_CHECKING:
     from asyncio import Task
@@ -36,6 +36,7 @@ if t.TYPE_CHECKING:
         ReceivesContext,
         SettingsDict,
         TimersDict,
+        QueueStats,
     )
 
 
@@ -47,6 +48,7 @@ class Worker:
     Worker is used to process and monitor jobs.
 
     Args:
+        id: optional override for the worker id, if not provided, uuid will be used
         queue: instance of saq.queue.Queue
         functions: list of async functions
         concurrency: number of jobs to process concurrently
@@ -72,6 +74,7 @@ class Worker:
         queue: Queue,
         functions: Collection[Function | tuple[str, Function]],
         *,
+        id: t.Optional[str] = None,
         concurrency: int = 10,
         cron_jobs: Collection[CronJob] | None = None,
         startup: ReceivesContext | Collection[ReceivesContext] | None = None,
@@ -115,6 +118,7 @@ class Worker:
         self.burst_jobs_processed = 0
         self.burst_jobs_processed_lock = threading.Lock()
         self.burst_condition_met = False
+        self.id = id if id is not None else uuid1()
 
         if self.burst:
             if self.dequeue_timeout <= 0:
@@ -151,6 +155,7 @@ class Worker:
         """Start processing jobs and upkeep tasks."""
         logger.info("Worker starting: %s", repr(self.queue))
         logger.debug("Registered functions:\n%s", "\n".join(f"  {key}" for key in self.functions))
+        await self.stats()
 
         try:
             self.event = asyncio.Event()
@@ -213,6 +218,9 @@ class Worker:
         if scheduled:
             logger.info("Scheduled %s", scheduled)
 
+    async def stats(self, ttl: int = 60) -> QueueStats:
+        return await self.queue.stats(self.id, ttl)
+
     async def upkeep(self) -> list[Task[None]]:
         """Start various upkeep tasks async."""
 
@@ -233,9 +241,7 @@ class Worker:
             asyncio.create_task(poll(self.abort, self.timers["abort"])),
             asyncio.create_task(poll(self.schedule, self.timers["schedule"])),
             asyncio.create_task(poll(self.queue.sweep, self.timers["sweep"])),
-            asyncio.create_task(
-                poll(self.queue.stats, self.timers["stats"], self.timers["stats"] + 1)
-            ),
+            asyncio.create_task(poll(self.stats, self.timers["stats"], self.timers["stats"] + 1)),
         ]
 
     async def abort(self, abort_threshold: float) -> None:

--- a/tests/test_http_stats.py
+++ b/tests/test_http_stats.py
@@ -1,0 +1,74 @@
+"""Validate that the worker id in the context of the http proxy is the id of the worker rather than the queue."""
+
+import unittest
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+from saq import Queue
+from saq.queue.http import HttpProxy
+from saq.types import Context
+from tests.helpers import setup_postgres, create_postgres_queue
+import asyncio
+import threading
+
+
+async def echo(_ctx: Context, *, a: int) -> int:
+    return a
+
+
+class ProxyRequestHandler(BaseHTTPRequestHandler):
+    def __init__(self, *args, proxy=None, **kwargs):
+        self.proxy = proxy
+        super().__init__(*args, **kwargs)
+
+    def do_POST(self):
+        length = int(self.headers["Content-Length"])
+        body = self.rfile.read(length).decode("utf-8")
+        response = asyncio.run(self.proxy.process(body))
+        if response:
+            self.send_response(200)
+            self.send_header("Content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(response.encode("utf-8"))
+        else:
+            self.send_response(200)
+            self.end_headers()
+
+
+class TestQueue(unittest.IsolatedAsyncioTestCase):
+    async def test_http_proxy_with_two_workers(self) -> None:
+        await setup_postgres()
+        queue = await create_postgres_queue()
+        proxy = HttpProxy(queue=queue)
+
+        server = HTTPServer(
+            ("localhost", 8080),
+            lambda *args, **kwargs: ProxyRequestHandler(*args, proxy=proxy, **kwargs),
+        )
+        server_thread = threading.Thread(target=server.serve_forever)
+        server_thread.daemon = True
+        server_thread.start()
+
+        queue1 = Queue.from_url("http://localhost:8080/")
+        await queue1.connect()
+        queue2 = Queue.from_url("http://localhost:8080/")
+        await queue2.connect()
+
+        await queue.stats()
+        await queue1.stats()
+        await queue2.stats()
+
+        root_info = await queue.info()
+        info1 = await queue1.info()
+        info2 = await queue2.info()
+
+        self.assertEqual(root_info["workers"], info1["workers"])
+        self.assertEqual(info1["workers"], info2["workers"])
+        self.assertEqual(info1["workers"].keys(), {queue.uuid, queue1.uuid, queue2.uuid})
+        self.assertEqual(info1["workers"].keys(), info2["workers"].keys())
+
+        await queue1.disconnect()
+        await queue2.disconnect()
+        await queue.disconnect()
+
+        server.shutdown()
+        server_thread.join()

--- a/tests/test_http_stats.py
+++ b/tests/test_http_stats.py
@@ -1,58 +1,44 @@
 """Validate that the worker id in the context of the http proxy is the id of the worker rather than the queue."""
 
 import unittest
-from http.server import HTTPServer, BaseHTTPRequestHandler
+from aiohttp import web
 
 from saq import Queue, Worker
 from saq.queue.http import HttpProxy
 from saq.types import Context
 from tests.helpers import setup_postgres, create_postgres_queue, teardown_postgres
-import asyncio
-import threading
 
 
 async def echo(_ctx: Context, *, a: int) -> int:
     return a
 
 
-class ProxyRequestHandler(BaseHTTPRequestHandler):
-    def __init__(self, *args, proxy=None, **kwargs):
-        self.proxy = proxy
-        super().__init__(*args, **kwargs)
-
-    def do_POST(self):
-        length = int(self.headers["Content-Length"])
-        body = self.rfile.read(length).decode("utf-8")
-        response = asyncio.run(self.proxy.process(body))
-        if response:
-            self.send_response(200)
-            self.send_header("Content-type", "application/json")
-            self.end_headers()
-            self.wfile.write(response.encode("utf-8"))
-        else:
-            self.send_response(200)
-            self.end_headers()
-
-
 class TestQueue(unittest.IsolatedAsyncioTestCase):
+    async def handle_post(self, request):
+        body = await request.text()
+        response = await self.proxy.process(body)
+        if response:
+            return web.Response(text=response, content_type="application/json")
+        else:
+            return web.Response(status=200)
+
     async def asyncSetUp(self) -> None:
         await setup_postgres()
+        self.queue = await create_postgres_queue()
+        self.proxy = HttpProxy(queue=self.queue)
+        self.app = web.Application()
+        self.app.add_routes([web.post("/", self.handle_post)])
+        self.runner = web.AppRunner(self.app)
+        await self.runner.setup()
+        self.site = web.TCPSite(self.runner, "localhost", 8080)
+        await self.site.start()
 
     async def asyncTearDown(self) -> None:
         await teardown_postgres()
+        await self.site.stop()
+        await self.runner.cleanup()
 
     async def test_http_proxy_with_two_workers(self) -> None:
-        queue = await create_postgres_queue()
-        proxy = HttpProxy(queue=queue)
-
-        server = HTTPServer(
-            ("localhost", 8080),
-            lambda *args, **kwargs: ProxyRequestHandler(*args, proxy=proxy, **kwargs),
-        )
-        server_thread = threading.Thread(target=server.serve_forever)
-        server_thread.daemon = True
-        server_thread.start()
-
         queue1 = Queue.from_url("http://localhost:8080/")
         await queue1.connect()
         queue2 = Queue.from_url("http://localhost:8080/")
@@ -69,12 +55,12 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
         )
         await worker2.stats()
         local_worker = Worker(
-            queue=queue,
+            queue=self.queue,
             functions=[echo],
         )
         await local_worker.stats()
 
-        root_info = await queue.info()
+        root_info = await self.queue.info()
         info1 = await queue1.info()
         info2 = await queue2.info()
 
@@ -85,7 +71,4 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
 
         await queue1.disconnect()
         await queue2.disconnect()
-        await queue.disconnect()
-
-        server.shutdown()
-        server_thread.join()
+        await self.queue.disconnect()


### PR DESCRIPTION
**FIRST COMMIT**

Currently, stats are written to the store by the Queue class, and before a Queue instance contains a UUID used to identify the worker.

When a Postgres or Redis Queue is created inside a worker, the ID will be unique to that worker, and the stats are stored as expected. In this case, a Queue instance is created with a unique ID wrapped in a Worker class, which then pushes the stats to the store with the ID from that queue instance, which is unique to that worker. 

This is currently not quite the case with HTTP. In an HTTP Proxy scenario, the proxy creates a Queue instance that contains a unique ID for the worker, as is done in the case of Redis and Postgres. When an HTTP worker Queue is created, this instance will contain the unique ID representative of that worker. When, however, the HTTP worker reports its stats, these, rather than being associated with the ID associated with the worker, are related to the ID of the queue instance in the proxy server.

This allows the stats to be attributed to the worker id rather than the id in the proxy. 

**SECOND COMMIT**

In the second commit, I corrected what I think is a semantic error: a queue should not have a worker_id, currently stored under `uuid` in a Queue instance. The second commit removes this id and puts it inside a Worker instance. 
