### PR TITLE
feat!: adding metadata to workers

### DIFF
--- a/saq/queue/base.py
+++ b/saq/queue/base.py
@@ -144,6 +144,12 @@ class Queue(ABC):
         pass
 
     @abstractmethod
+    async def write_worker_metadata(
+        self, worker_id: str, queue_key: str, ip_address: str, metadata: t.Optional[dict], ttl: int
+    ) -> None:
+        pass
+
+    @abstractmethod
     async def _retry(self, job: Job, error: str | None) -> None:
         pass
 

--- a/saq/queue/http.py
+++ b/saq/queue/http.py
@@ -107,6 +107,15 @@ class HttpProxy:
                     worker_id=req["worker_id"], stats=req["stats"], ttl=req["ttl"]
                 )
                 return None
+            if kind == "write_worker_metadata":
+                await self.queue.write_worker_metadata(
+                    metadata=req["metadata"],
+                    ttl=req["ttl"],
+                    ip_address=req["ip_address"],
+                    queue_key=req["queue_key"],
+                    worker_id=req["worker_id"],
+                )
+                return None
         raise ValueError(f"Invalid request {body}")
 
 
@@ -210,6 +219,18 @@ class HttpQueue(Queue):
 
     async def write_stats(self, worker_id: str, stats: WorkerStats, ttl: int) -> None:
         await self._send("write_stats", worker_id=worker_id, stats=stats, ttl=ttl)
+
+    async def write_worker_metadata(
+        self, worker_id: str, queue_key: str, ip_address: str, metadata: t.Optional[dict], ttl: int
+    ) -> None:
+        await self._send(
+            "write_worker_metadata",
+            worker_id=worker_id,
+            metadata=metadata,
+            ttl=ttl,
+            ip_address=ip_address,
+            queue_key=queue_key,
+        )
 
     async def info(self, jobs: bool = False, offset: int = 0, limit: int = 10) -> QueueInfo:
         return json.loads(await self._send("info", jobs=jobs, offset=offset, limit=limit))

--- a/saq/queue/postgres.py
+++ b/saq/queue/postgres.py
@@ -33,6 +33,7 @@ if t.TYPE_CHECKING:
         LoadType,
         QueueInfo,
         WorkerStats,
+        WorkerInfo,
     )
 
 try:
@@ -49,6 +50,7 @@ ENQUEUE = "saq:enqueue"
 DEQUEUE = "saq:dequeue"
 JOBS_TABLE = "saq_jobs"
 STATS_TABLE = "saq_stats"
+METADATA_TABLE = "saq_worker_metadata"
 
 
 class PostgresQueue(Queue):
@@ -90,6 +92,7 @@ class PostgresQueue(Queue):
         name: str = "default",
         jobs_table: str = JOBS_TABLE,
         stats_table: str = STATS_TABLE,
+        metadata_table: str = METADATA_TABLE,
         dump: DumpType | None = None,
         load: LoadType | None = None,
         min_size: int = 4,
@@ -103,6 +106,7 @@ class PostgresQueue(Queue):
 
         self.jobs_table = Identifier(jobs_table)
         self.stats_table = Identifier(stats_table)
+        self.metadata_table = Identifier(metadata_table)
         self.pool = pool
         self.min_size = min_size
         self.max_size = max_size
@@ -134,7 +138,11 @@ class PostgresQueue(Queue):
 
             for statement in DDL_STATEMENTS:
                 await cursor.execute(
-                    SQL(statement).format(jobs_table=self.jobs_table, stats_table=self.stats_table)
+                    SQL(statement).format(
+                        jobs_table=self.jobs_table,
+                        stats_table=self.stats_table,
+                        worker_metadata_table=self.metadata_table,
+                    )
                 )
 
     async def connect(self) -> None:
@@ -163,20 +171,55 @@ class PostgresQueue(Queue):
         await self.pool.close()
         self._has_sweep_lock = False
 
+    async def write_worker_metadata(
+        self, worker_id: str, queue_key: str, ip_address: str, metadata: t.Optional[dict], ttl: int
+    ) -> None:
+        async with self.pool.connection() as conn:
+            await conn.execute(
+                SQL(
+                    dedent(
+                        """
+                        INSERT INTO {worker_metadata_table} (worker_id, queue_key, ip_address, metadata, expire_at)
+                        VALUES 
+                            (%(worker_id)s, %(queue_key)s, %(ip_address)s, %(metadata)s, EXTRACT(EPOCH FROM NOW()) + %(ttl)s) 
+                        ON CONFLICT (worker_id) DO UPDATE
+                        SET metadata = %(metadata)s, queue_key = %(queue_key)s, ip_address = %(ip_address)s, expire_at = EXTRACT(EPOCH FROM NOW()) + %(ttl)s
+                        """
+                    )
+                ).format(worker_metadata_table=self.metadata_table),
+                {
+                    "worker_id": worker_id,
+                    "metadata": json.dumps(metadata),
+                    "queue_key": queue_key,
+                    "ip_address": ip_address,
+                    "ttl": ttl,
+                },
+            )
+
     async def info(self, jobs: bool = False, offset: int = 0, limit: int = 10) -> QueueInfo:
         async with self.pool.connection() as conn, conn.cursor() as cursor:
             await cursor.execute(
                 SQL(
                     dedent(
                         """
-                        SELECT worker_id, stats FROM {stats_table}
-                        WHERE NOW() <= TO_TIMESTAMP(expire_at)
+                        SELECT stats.worker_id, stats.stats, meta.queue_key, meta.ip_address, meta.metadata
+                        FROM {stats_table} stats
+                        LEFT JOIN {worker_metadata_table} meta ON meta.worker_id = stats.worker_id
+                        WHERE NOW() <= TO_TIMESTAMP(stats.expire_at) 
                         """
                     )
-                ).format(stats_table=self.stats_table),
+                ).format(stats_table=self.stats_table, worker_metadata_table=self.metadata_table),
             )
             results = await cursor.fetchall()
-        workers: dict[str, dict[str, t.Any]] = dict(results)
+        workers: dict[str, WorkerInfo] = {
+            worker_id: {
+                "stats": stats,
+                "metadata": metadata,
+                "queue_key": queue_key,
+                "ip_address": ip_address,
+            }
+            for worker_id, stats, queue_key, ip_address, metadata in results
+        }
 
         queued = await self.count("queued")
         active = await self.count("active")
@@ -316,6 +359,21 @@ class PostgresQueue(Queue):
                 ).format(
                     jobs_table=self.jobs_table,
                     stats_table=self.stats_table,
+                ),
+                {"now": now_ts},
+            )
+
+            await cursor.execute(
+                SQL(
+                    dedent(
+                        """
+                        -- Delete expired worker metadata
+                        DELETE FROM {worker_metadata_table}
+                        WHERE %(now)s >= expire_at;
+                        """
+                    )
+                ).format(
+                    worker_metadata_table=self.metadata_table,
                 ),
                 {"now": now_ts},
             )

--- a/saq/queue/postgres_ddl.py
+++ b/saq/queue/postgres_ddl.py
@@ -24,8 +24,19 @@ CREATE TABLE IF NOT EXISTS {stats_table} (
 );
 """
 
+CREATE_WORKER_METADATA_TABLE = """
+CREATE TABLE IF NOT EXISTS {worker_metadata_table} (
+    worker_id TEXT PRIMARY KEY,
+    queue_key TEXT NOT NULL,
+    expire_at BIGINT NOT NULL,
+    ip_address TEXT,
+    metadata JSONB 
+);
+"""
+
 DDL_STATEMENTS = [
     CREATE_JOBS_TABLE,
     CREATE_JOBS_DEQUEUE_INDEX,
     CREATE_STATS_TABLE,
+    CREATE_WORKER_METADATA_TABLE,
 ]

--- a/saq/queue/redis.py
+++ b/saq/queue/redis.py
@@ -40,6 +40,7 @@ if t.TYPE_CHECKING:
         QueueInfo,
         WorkerStats,
         VersionTuple,
+        WorkerInfo,
     )
 
 ID_PREFIX = "saq:job:"
@@ -133,12 +134,29 @@ class RedisQueue(Queue):
         worker_stats = await self.redis.mget(
             self.namespace(f"stats:{worker_uuid}") for worker_uuid in worker_uuids
         )
-
-        worker_info = {}
-        for worker_uuid, stats in zip(worker_uuids, worker_stats):
+        worker_metadata = await self.redis.mget(
+            self.namespace(f"metadata:{worker_uuid}") for worker_uuid in worker_uuids
+        )
+        workers: dict[str, WorkerInfo] = {}
+        worker_metadata_dict = dict(zip(worker_uuids, worker_metadata))
+        worker_stats_dict = dict(zip(worker_uuids, worker_stats))
+        for worker in worker_uuids:
+            workers[worker] = {
+                "queue_key": None,
+                "ip_address": None,
+                "stats": None,
+                "metadata": None,
+            }
+            metadata = worker_metadata_dict[worker]
+            if metadata:
+                metadata_obj = json.loads(metadata)
+                workers[worker]["metadata"] = metadata_obj["metadata"]
+                workers[worker]["ip_address"] = metadata_obj["ip_address"]
+                workers[worker]["queue_key"] = metadata_obj["queue_key"]
+            stats = worker_stats_dict[worker]
             if stats:
                 stats_obj = json.loads(stats)
-                worker_info[worker_uuid] = stats_obj
+                workers[worker]["stats"] = stats_obj
 
         queued = await self.count("queued")
         active = await self.count("active")
@@ -166,7 +184,7 @@ class RedisQueue(Queue):
             job_info = []
 
         return {
-            "workers": worker_info,
+            "workers": workers,
             "name": self.name,
             "queued": queued,
             "active": active,
@@ -400,6 +418,14 @@ class RedisQueue(Queue):
                 .expire(self._stats, ttl)
                 .execute()
             )
+
+    async def write_worker_metadata(
+        self, worker_id: str, queue_key: str, ip_address: str, metadata: t.Optional[dict], ttl: int
+    ) -> None:
+        async with self.redis.pipeline(transaction=True) as pipe:
+            key = self.namespace(f"metadata:{worker_id}")
+            metadata = {"queue_key": queue_key, "ip_address": ip_address, "metadata": metadata}
+            await pipe.setex(key, ttl, json.dumps(metadata)).expire(key, ttl).execute()
 
     async def _retry(self, job: Job, error: str | None) -> None:
         job_id = job.id

--- a/saq/types.py
+++ b/saq/types.py
@@ -45,12 +45,23 @@ class JobTaskContext(t.TypedDict, total=False):
     "If this task has been aborted, this is the reason"
 
 
+class WorkerInfo(t.TypedDict):
+    """
+    Worker Info
+    """
+
+    queue_key: t.Optional[str]
+    ip_address: t.Optional[str]
+    stats: t.Optional[WorkerStats]
+    metadata: t.Optional[dict[str, t.Any]]
+
+
 class QueueInfo(t.TypedDict):
     """
     Queue Info
     """
 
-    workers: dict[str, dict[str, t.Any]]
+    workers: dict[str, WorkerInfo]
     "Worker information"
     name: str
     "Queue name"
@@ -93,6 +104,8 @@ class TimersDict(t.TypedDict):
     "How often to clean up stuck jobs in seconds (default 60)"
     abort: int
     "How often to check if a job is aborted in seconds (default 1)"
+    metadata: int
+    "How often to write worker metadata in seconds (default 60)"
 
 
 class PartialTimersDict(TimersDict, total=False):

--- a/saq/worker.py
+++ b/saq/worker.py
@@ -9,6 +9,7 @@ import contextvars
 import logging
 import os
 import signal
+import socket
 import sys
 import traceback
 import threading
@@ -42,6 +43,9 @@ if t.TYPE_CHECKING:
 
 logger = logging.getLogger("saq")
 
+# Type that represents arbitrary json
+JsonDict = t.Dict[str, t.Any]
+
 
 class Worker:
     """
@@ -65,6 +69,7 @@ class Worker:
         dequeue_timeout: how long it will wait to dequeue
         burst: whether to stop the worker once all jobs have been processed
         max_burst_jobs: the maximum number of jobs to process in burst mode
+        metadata: arbitrary data to pass to the worker which it will register with saq
     """
 
     SIGNALS = [signal.SIGINT, signal.SIGTERM] if os.name != "nt" else [signal.SIGTERM]
@@ -85,6 +90,7 @@ class Worker:
         dequeue_timeout: float = 0,
         burst: bool = False,
         max_burst_jobs: int | None = None,
+        metadata: t.Optional[JsonDict] = None,
     ) -> None:
         self.queue = queue
         self.concurrency = concurrency
@@ -102,6 +108,7 @@ class Worker:
             "stats": 10,
             "sweep": 60,
             "abort": 1,
+            "metadata": 60,
         }
         if timers is not None:
             self.timers.update(timers)
@@ -118,6 +125,8 @@ class Worker:
         self.burst_jobs_processed = 0
         self.burst_jobs_processed_lock = threading.Lock()
         self.burst_condition_met = False
+        self._metadata = metadata
+        self._ip_address = get_ip_address()
         self.id = uuid1() if id is None else id
 
         if self.burst:
@@ -217,6 +226,15 @@ class Worker:
         if scheduled:
             logger.info("Scheduled %s", scheduled)
 
+    async def metadata(self, ttl: int = 60) -> None:
+        await self.queue.write_worker_metadata(
+            queue_key=self.queue.name,
+            ip_address=self._ip_address,
+            metadata=self._metadata,
+            ttl=ttl,
+            worker_id=self.id,
+        )
+
     async def stats(self, ttl: int = 60) -> WorkerStats:
         return await self.queue.stats(self.id, ttl)
 
@@ -241,6 +259,7 @@ class Worker:
             asyncio.create_task(poll(self.schedule, self.timers["schedule"])),
             asyncio.create_task(poll(self.queue.sweep, self.timers["sweep"])),
             asyncio.create_task(poll(self.stats, self.timers["stats"], self.timers["stats"] + 1)),
+            asyncio.create_task(poll(self.metadata, self.timers["metadata"])),
         ]
 
     async def abort(self, abort_threshold: float) -> None:
@@ -464,3 +483,10 @@ def check_health(settings: str) -> int:
     loop = asyncio.new_event_loop()
     queue = settings_dict.get("queue") or Queue.from_url("redis://localhost")
     return loop.run_until_complete(async_check_health(queue))
+
+
+def get_ip_address() -> str:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+        s.connect(("8.8.8.8", 80))
+        ip_address = s.getsockname()[0]
+    return ip_address

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -211,7 +211,11 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
     async def test_info(self) -> None:
         queue2 = await self.create_queue(name=self.queue.name)
         self.addAsyncCleanup(cleanup_queue, queue2)
-        worker = Worker(self.queue, functions=functions)
+        worker = Worker(
+            self.queue,
+            functions=functions,
+            metadata={"foo": "bar"},
+        )
         info = await self.queue.info(jobs=True)
         self.assertEqual(info["workers"], {})
         self.assertEqual(info["active"], 0)
@@ -223,12 +227,22 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
         await queue2.enqueue("echo", a=1)
         await worker.process()
         await worker.stats()
+        await worker.metadata(3)
 
         info = await self.queue.info(jobs=True)
         self.assertEqual(set(info["workers"].keys()), {worker.id})
+        self.assertEqual(info["workers"][worker.id]["metadata"], {"foo": "bar"})
+        self.assertEqual(info["workers"][worker.id]["queue_key"], self.queue.name)
+        self.assertEqual(len(info["workers"][worker.id]["ip_address"].split(".")), 4)
+        assert info["workers"][worker.id]["stats"] is not None
         self.assertEqual(info["active"], 0)
         self.assertEqual(info["queued"], 1)
         self.assertEqual(len(info["jobs"]), 1)
+
+        time.sleep(4)
+        await worker.queue.sweep()
+        info = await self.queue.info(jobs=True)
+        self.assertEqual(info["workers"][worker.id]["metadata"], None)
 
     @mock.patch("saq.utils.time")
     async def test_schedule(self, mock_time: MagicMock) -> None:


### PR DESCRIPTION
- add table to store metadata for workers, queue and ip address
- add ip_address and queue_name that worker is working on
- add optional ability for workers to add metadata to that table
- in info moved stats for a particular worker under stats which sits side by side now with metadata than straight inside a worker