### PR TITLE
add timezone to cron scheduler

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
             "pre-commit",
             "redis>=4.2,<6.0",
             "ruff",
+            "time-machine",
             "types-croniter",
             "types-redis",
             "types-setuptools",

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -391,23 +391,17 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
             await asyncio.sleep(1)
             self.assertEqual(await self.queue.count("incomplete"), 1)
 
-            traveller.move_to(
-                datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-            )  # noon UTC
+            traveller.move_to(datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc))  # noon UTC
             await asyncio.sleep(2)
             self.assertEqual(await self.queue.count("active"), 0)
 
-            traveller.move_to(
-                datetime(2025, 1, 1, 15, 0, 0, tzinfo=timezone.utc)
-            )  # noon in tz
+            traveller.move_to(datetime(2025, 1, 1, 15, 0, 0, tzinfo=timezone.utc))  # noon in tz
             await asyncio.sleep(2)
             self.assertEqual(await self.queue.count("active"), 1)
 
             # Remove if statement when schedule is implemented for Postgres queue
             if isinstance(self.queue, RedisQueue):
-                mock_logger.info.assert_any_call(
-                    "Scheduled %s", ["saq:job:default:cron:sleeper"]
-                )
+                mock_logger.info.assert_any_call("Scheduled %s", ["saq:job:default:cron:sleeper"])
 
     @mock.patch("saq.worker.logger")
     async def test_abort(self, mock_logger: MagicMock) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -382,14 +382,16 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
             worker = Worker(
                 self.queue,
                 functions=functions,
-                cron_jobs=[CronJob(sleeper, cron="* 12 * * *", kwargs={"sleep": 5})],
+                cron_jobs=[CronJob(sleeper, cron="* 12 * * *", kwargs={"sleep": 3})],
                 cron_tz=timezone(offset=timedelta(hours=-3)),  # 3 hours behind (UTC-3)
             )
             await worker.queue.connect()
             self.assertEqual(await self.queue.count("incomplete"), 0)
+            self.assertEqual(await self.queue.count("queued"), 0)
             asyncio.create_task(worker.start())
             await asyncio.sleep(1)
             self.assertEqual(await self.queue.count("incomplete"), 1)
+            self.assertEqual(await self.queue.count("queued"), 0)
 
             traveller.move_to(datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc))  # noon UTC
             await asyncio.sleep(2)


### PR DESCRIPTION
Hi, thanks for this cool project!

I want to use SAQ for a trading app, where taking into account New York time (and DST) is very important. Currently there is no way to do this as far as I can tell, but it's a small change!
I am unfamiliar with `unittest`, so I may need some guidance making sure the tests work correctly here and adding new ones.
