### PR TITLE
fix: allow aborting jobs to be swept

### DIFF
--- a/saq/job.py
+++ b/saq/job.py
@@ -242,7 +242,7 @@ class Job:
     def stuck(self) -> bool:
         """Checks if an active job is passed its timeout or heartbeat."""
         current = now()
-        return (self.status == Status.ACTIVE) and bool(
+        return (self.status == Status.ACTIVE or self.status == Status.ABORTING) and bool(
             (self.timeout and seconds(current - self.started) > self.timeout)
             or (self.heartbeat and seconds(current - self.touched) > self.heartbeat)
         )

--- a/saq/worker.py
+++ b/saq/worker.py
@@ -274,7 +274,7 @@ class Worker:
             return
 
         for job in await self.queue.jobs(job.key for job in jobs):
-            if not job or job.status != Status.ABORTING:
+            if not job or job.status not in (Status.ABORTING, Status.ABORTED):
                 continue
 
             task_data: JobTaskContext = self.job_task_contexts.get(job, {})

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -71,7 +71,10 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.job.error, "error")
 
     async def test_stuck(self) -> None:
-        self.assertFalse(Job("", status=Status.ACTIVE, timeout=0).stuck)
+        self.assertFalse(Job("", status=Status.ACTIVE, timeout=0, started=0).stuck)
+        self.assertFalse(Job("", status=Status.COMPLETE, timeout=0, started=0).stuck)
+        self.assertTrue(Job("", status=Status.ACTIVE, timeout=1, started=0).stuck)
+        self.assertTrue(Job("", status=Status.ABORTING, timeout=1, started=0).stuck)
 
     async def test_update(self) -> None:
         self.assertEqual(self.job.attempts, 0)


### PR DESCRIPTION
with the http queue, jobs can be forever stuck in aborting because the server (postgres) continues to hold onto the lock. this makes it so that they will move onto aborted despite the lock. the worker additionally will check for aborted/aborting.