### PR TITLE
fix!: update defaults to not touching status

### DIFF
--- a/saq/job.py
+++ b/saq/job.py
@@ -292,10 +292,10 @@ class Job:
         Updates the stored job in redis.
 
         Set properties with passed in kwargs.
+
+        If status is not explicitly passed in, the status will not update as this is usually controlled by the workers.
         """
-        for k, v in kwargs.items():
-            setattr(self, k, v)
-        await self.get_queue().update(self)
+        await self.get_queue().update(self, **kwargs)
 
     async def refresh(self, until_complete: float | None = None) -> None:
         """

--- a/saq/queue/base.py
+++ b/saq/queue/base.py
@@ -102,8 +102,15 @@ class Queue(ABC):
     async def notify(self, job: Job) -> None:
         pass
 
+    async def update(self, job: Job, **kwargs: t.Any) -> None:
+        job.touched = now()
+        for k, v in kwargs.items():
+            if hasattr(job, k):
+                setattr(job, k, v)
+        await self._update(job, **kwargs)
+
     @abstractmethod
-    async def update(self, job: Job) -> None:
+    async def _update(self, job: Job, status: Status | None = None, **kwargs: t.Any) -> None:
         pass
 
     @abstractmethod

--- a/saq/worker.py
+++ b/saq/worker.py
@@ -298,9 +298,8 @@ class Worker:
                 return False
 
             job.started = now()
-            job.status = Status.ACTIVE
             job.attempts += 1
-            await job.update()
+            await job.update(status=Status.ACTIVE)
             context = {**self.context, "job": job}
             await self._before_process(context)
             logger.info("Processing %s", job.info(logger.isEnabledFor(logging.DEBUG)))


### PR DESCRIPTION
prior to this commit, job.update() would also override status, this is problematic when using update() for heartbeats since it would override an abort. now, a job status only gets updated if status is passed in directly.