### PR TITLE
Feat: Improve Postgres dequeue performance with additional indexes

### DIFF
--- a/saq/queue/postgres_migrations.py
+++ b/saq/queue/postgres_migrations.py
@@ -56,4 +56,16 @@ CREATE INDEX IF NOT EXISTS saq_stats_queue_key_idx ON {stats_table} (queue_key);
                 ).format(stats_table=stats_table),
             ],
         ),
+        (
+            3,
+            [
+                SQL(
+                    dedent("""
+CREATE INDEX IF NOT EXISTS saq_jobs_status_queue_group_key_idx ON {jobs_table} (status, queue, group_key);
+CREATE INDEX IF NOT EXISTS saq_jobs_status_queue_priority_scheduled_idx ON {jobs_table} (status, queue, priority, scheduled);
+DROP INDEX saq_jobs_dequeue_idx;
+        """)
+                ).format(jobs_table=jobs_table),
+            ],
+        ),
     ]

--- a/saq/worker.py
+++ b/saq/worker.py
@@ -223,10 +223,10 @@ class Worker:
                 **{k: v for k, v in kwargs.items() if v is not None},
             )
 
-        scheduled = await self.queue.schedule(lock)
+        job_ids = await self.queue.schedule(lock)
 
-        if scheduled:
-            logger.info("Scheduled %s", scheduled)
+        if job_ids:
+            logger.info("Scheduled %s", job_ids)
 
     async def worker_info(self, ttl: int = 60) -> WorkerInfo:
         return await self.queue.worker_info(


### PR DESCRIPTION
These index probably won't be used by the query planner unless the jobs table has hundreds of thousands of rows, but they do significantly speed up the query when there are that many jobs.