### PR TITLE
literalinclude monitor_fastapi.py as FastAPI monitor example

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -27,13 +27,8 @@ Module {py:class}`saq.web.starlette` contains a starlette instance for use in an
 
 ::::{tab-set}
 :::{tab-item} FastAPI
-```python
-from fastapi import FastAPI
-from saq.web.starlette import saq_web
-
-app = FastAPI()
-
-app.mount("/monitor", saq_web("/monitor", queues=all_the_queues_list))
+```{literalinclude} ../examples/monitor_fastapi.py
+:end-before: end-of-example
 ```
 :::
 

--- a/examples/monitor_fastapi.py
+++ b/examples/monitor_fastapi.py
@@ -1,0 +1,28 @@
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+from saq import Queue
+from saq.web.starlette import saq_web
+
+# import it from your module where you defined your settings
+queue = Queue.from_url("postgres://postgres@localhost")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await queue.connect()
+
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+app.mount("/monitor", saq_web("/monitor", queues=[queue]))
+
+# end-of-example
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
In general I think it is a good way to include examples from files. This way linters & formatters can help keeping the code up-to date. 

An even better way would be to references examples from tests. 