### PR TITLE
fix: prevent zombie web worker

### DIFF
--- a/saq/worker.py
+++ b/saq/worker.py
@@ -449,7 +449,9 @@ def start(
         app = create_app(queues)
         app.on_shutdown.append(shutdown)
 
-        loop.create_task(worker_start())
+        loop.create_task(worker_start()).add_done_callback(
+            lambda _: signal.raise_signal(signal.SIGTERM)
+        )
         aiohttp.web.run_app(app, port=port, loop=loop)
     else:
         loop.run_until_complete(worker_start())


### PR DESCRIPTION
Prior to this PR, if a worker stopped due to an exception then the web app would keep running despite the fact that there are no workers available. This change makes it so that when the worker stops then it emits a sigterm in order to bring down the web app too. 