### PR TITLE
fix: race condition when refreshing and updating simultaneously, the …

### DIFF
--- a/saq/job.py
+++ b/saq/job.py
@@ -174,12 +174,18 @@ class Job:
 
         if "queue" in kwargs:
             kwargs["queue"] = kwargs["queue"].name
+        if "status" in kwargs:
+            kwargs["status"] = kwargs["status"].name.lower()
 
         if not kwargs.get("meta"):
             kwargs.pop("meta", None)
 
         info = ", ".join(f"{k}: {v}" for k, v in kwargs.items())
         return f"Job<{info}>"
+
+    def __post_init__(self) -> None:
+        if isinstance(self.status, str):
+            self.status = Status[self.status.upper()]
 
     def __repr__(self) -> str:
         return self.info(True)

--- a/saq/queue/base.py
+++ b/saq/queue/base.py
@@ -118,7 +118,7 @@ class Queue(ABC):
         for k, v in kwargs.items():
             if hasattr(job, k):
                 setattr(job, k, v)
-        await self._update(job, **kwargs)
+        await self._update(self.copy(job), **kwargs)
 
     @abstractmethod
     async def _update(self, job: Job, status: Status | None = None, **kwargs: t.Any) -> None:
@@ -212,6 +212,9 @@ class Queue(ABC):
 
     async def connect(self) -> None:
         self._loop = asyncio.get_running_loop()
+
+    def copy(self, job: Job) -> Job:
+        return self.deserialize(job.to_dict())  # type: ignore
 
     def serialize(self, job: Job) -> bytes | str:
         return self._dump(job.to_dict())

--- a/saq/queue/postgres.py
+++ b/saq/queue/postgres.py
@@ -784,7 +784,7 @@ class PostgresQueue(Queue):
                 SQL(
                     dedent(
                         """
-                        SELECT status
+                        SELECT UPPER(status)
                         FROM {jobs_table}
                         WHERE key = %(key)s
                         {for_update}
@@ -800,7 +800,7 @@ class PostgresQueue(Queue):
             )
             result = await cursor.fetchone()
             if result:
-                return result[0]
+                return Status[result[0]]
             return None
 
     async def _retry(self, job: Job, error: str | None) -> None:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -32,6 +32,10 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
     async def asyncTearDown(self) -> None:
         await cleanup_queue(self.queue)
 
+    def test_job_status_type(self) -> None:
+        job = Job("", status="new")
+        self.assertIs(job.status, Status.NEW)
+
     async def test_info(self) -> None:
         await self.job.enqueue()
         await self.job.update()


### PR DESCRIPTION
…update will be overriden mid task causing unexpected behavior