### PR TITLE
Add poll_interval argument to apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ print(job.results)
 # run a job and return the result
 print(await queue.apply("test", a=2))
 
+# run a job with custom polling interval to check status more frequently
+print(await queue.apply("test", a=2, poll_interval=0.1))
+
 # Run multiple jobs concurrently and collect the results into a list
 print(await queue.map("test", [{"a": 3}, {"a": 4}]))
 

--- a/saq/queue/base.py
+++ b/saq/queue/base.py
@@ -52,7 +52,9 @@ class JobError(Exception):
     """
 
     def __init__(self, job: Job) -> None:
-        super().__init__(f"Job {job.id} {job.status}\n\nThe above job failed with the following error:\n\n{job.error}")
+        super().__init__(
+            f"Job {job.id} {job.status}\n\nThe above job failed with the following error:\n\n{job.error}"
+        )
         self.job = job
 
 
@@ -411,7 +413,9 @@ class Queue(ABC):
             poll_interval: Number of seconds between checking job status (default 0.5)
             kwargs: Same as Queue.enqueue
         """
-        results = await self.map(job_or_func, timeout=timeout, poll_interval=poll_interval, iter_kwargs=[kwargs])
+        results = await self.map(
+            job_or_func, timeout=timeout, poll_interval=poll_interval, iter_kwargs=[kwargs]
+        )
         if results:
             return results[0]
         return None

--- a/saq/queue/base.py
+++ b/saq/queue/base.py
@@ -365,7 +365,7 @@ class Queue(ABC):
             job_keys: sequence of job keys
             callback: callback function, if it returns truthy, break
             timeout: if timeout is truthy, wait for timeout seconds
-            poll_interval: Number of seconds between checking job status
+            poll_interval: Number of seconds between checking job status (default 0.5)
         """
 
         async def listen() -> None:
@@ -404,7 +404,7 @@ class Queue(ABC):
         Args:
             job_or_func: Same as Queue.enqueue
             timeout: If provided, how long to wait for result, else infinite (default None)
-            poll_interval: Number of seconds between checking job status
+            poll_interval: Number of seconds between checking job status (default 0.5)
             kwargs: Same as Queue.enqueue
         """
         results = await self.map(job_or_func, timeout=timeout, poll_interval=poll_interval, iter_kwargs=[kwargs])
@@ -446,7 +446,7 @@ class Queue(ABC):
             return_exceptions: If False (default), an exception is immediately raised as soon as any jobs
                 fail. Other jobs won't be cancelled and will continue to run.
                 If True, exceptions are treated the same as successful results and aggregated in the result list.
-            poll_interval: Number of seconds between checking job status
+            poll_interval: Number of seconds between checking job status (default 0.5)
             kwargs: Default kwargs for all jobs. These will be overridden by those in iter_kwargs.
         """
         iter_kwargs = [

--- a/saq/queue/base.py
+++ b/saq/queue/base.py
@@ -28,12 +28,12 @@ if t.TYPE_CHECKING:
     from saq.types import (
         BeforeEnqueueType,
         CountKind,
-        ListenCallback,
         DumpType,
+        ListenCallback,
         LoadType,
         QueueInfo,
-        WorkerStats,
         WorkerInfo,
+        WorkerStats,
     )
 
 
@@ -52,9 +52,7 @@ class JobError(Exception):
     """
 
     def __init__(self, job: Job) -> None:
-        super().__init__(
-            f"Job {job.id} {job.status}\n\nThe above job failed with the following error:\n\n{job.error}"
-        )
+        super().__init__(f"Job {job.id} {job.status}\n\nThe above job failed with the following error:\n\n{job.error}")
         self.job = job
 
 
@@ -386,7 +384,13 @@ class Queue(ABC):
         else:
             await listen()
 
-    async def apply(self, job_or_func: str, timeout: float | None = None, poll_interval: float = 0.5, **kwargs: t.Any) -> t.Any:
+    async def apply(
+        self,
+        job_or_func: str,
+        timeout: float | None = None,
+        poll_interval: float = 0.5,
+        **kwargs: t.Any,
+    ) -> t.Any:
         """
         Enqueue a job and wait for its result.
 

--- a/saq/queue/base.py
+++ b/saq/queue/base.py
@@ -365,7 +365,7 @@ class Queue(ABC):
             job_keys: sequence of job keys
             callback: callback function, if it returns truthy, break
             timeout: if timeout is truthy, wait for timeout seconds
-            poll_interval: number of seconds in between poll attempts if needed
+            poll_interval: Number of seconds between checking job status
         """
 
         async def listen() -> None:
@@ -386,7 +386,7 @@ class Queue(ABC):
         else:
             await listen()
 
-    async def apply(self, job_or_func: str, timeout: float | None = None, **kwargs: t.Any) -> t.Any:
+    async def apply(self, job_or_func: str, timeout: float | None = None, poll_interval: float = 0.5, **kwargs: t.Any) -> t.Any:
         """
         Enqueue a job and wait for its result.
 
@@ -404,9 +404,10 @@ class Queue(ABC):
         Args:
             job_or_func: Same as Queue.enqueue
             timeout: If provided, how long to wait for result, else infinite (default None)
+            poll_interval: Number of seconds between checking job status
             kwargs: Same as Queue.enqueue
         """
-        results = await self.map(job_or_func, timeout=timeout, iter_kwargs=[kwargs])
+        results = await self.map(job_or_func, timeout=timeout, poll_interval=poll_interval, iter_kwargs=[kwargs])
         if results:
             return results[0]
         return None
@@ -445,7 +446,7 @@ class Queue(ABC):
             return_exceptions: If False (default), an exception is immediately raised as soon as any jobs
                 fail. Other jobs won't be cancelled and will continue to run.
                 If True, exceptions are treated the same as successful results and aggregated in the result list.
-            poll_interval: number of seconds in between poll attempts
+            poll_interval: Number of seconds between checking job status
             kwargs: Default kwargs for all jobs. These will be overridden by those in iter_kwargs.
         """
         iter_kwargs = [


### PR DESCRIPTION
#238 
Also adds a test case for poll_interval.

I'm not sure about the readme changes, but for my use-case (low latency tasks) the `poll_interval` is a crucial part in understanding how the library works and making it respond faster. The mentions of "avoids polling" in the readme were confusing to me as they do not say that it does not apply to the results.