### PR TITLE
fix: publish to channel

### DIFF
--- a/saq/queue/postgres.py
+++ b/saq/queue/postgres.py
@@ -957,4 +957,4 @@ class ListenMultiplexer(Multiplexer):
             await conn.execute(SQL("LISTEN {}").format(Identifier(self.key)))
 
             async for notify in conn.notifies():
-                self.publish(notify.payload, notify.payload)
+                self.publish(notify.channel, notify.payload)


### PR DESCRIPTION
Previous logic: 
```
async for notify in conn.notifies():
    payload = json.loads(notify.payload)
    self.publish(payload["key"], payload)
```

Change introduced in this PR: https://github.com/tobymao/saq/pull/228

I don't understand why this works at all today. Is this publish/notify optional? 