### PR TITLE
Refactor/extract runner from main

### DIFF
--- a/saq/__main__.py
+++ b/saq/__main__.py
@@ -1,10 +1,8 @@
 import argparse
-import logging
-import multiprocessing
 import os
 import sys
 
-from saq.worker import check_health, start
+from saq.runner import run
 
 
 def main() -> None:
@@ -57,39 +55,16 @@ def main() -> None:
     # Includes the current path as a module path to allow importlib finding in-development modules
     sys.path.append(os.getcwd())
 
-    if not args.quiet:
-        level = args.verbose
-
-        if level == 0:
-            level = logging.WARNING
-        elif level == 1:
-            level = logging.INFO
-        else:
-            level = logging.DEBUG
-
-        logging.basicConfig(level=level)
-
-    settings = args.settings
-
-    if args.check:
-        sys.exit(check_health(settings))
-    else:
-        workers = args.workers
-
-        if workers > 1:
-            for _ in range(workers - 1):
-                p = multiprocessing.Process(target=start, args=(settings,))
-                p.start()
-
-        try:
-            start(
-                settings,
-                web=args.web,
-                extra_web_settings=args.extra_web_settings,
-                port=args.port,
-            )
-        except KeyboardInterrupt:
-            pass
+    run(
+        args.settings,
+        workers=args.workers,
+        verbose=args.verbose,
+        web=args.web,
+        extra_web_settings=args.extra_web_settings,
+        port=args.port,
+        check=args.check,
+        quiet=args.quiet,
+    )
 
 
 if __name__ == "__main__":

--- a/saq/runner.py
+++ b/saq/runner.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import logging
+import multiprocessing
+import sys
+
+from saq.worker import check_health, start
+
+
+def run(
+    settings: str,
+    /,
+    *,
+    workers: int = 1,
+    verbose: int = 0,
+    web: bool = False,
+    extra_web_settings: list[str] | None = None,
+    port: int = 8080,
+    check: bool = False,
+    quiet: bool = False,
+) -> None:
+    if not quiet:
+        level = verbose
+
+        if level == 0:
+            level = logging.WARNING
+        elif level == 1:
+            level = logging.INFO
+        else:
+            level = logging.DEBUG
+
+        logging.basicConfig(level=level)
+
+    if check:
+        sys.exit(check_health(settings))
+    else:
+        if workers > 1:
+            for _ in range(workers - 1):
+                p = multiprocessing.Process(target=start, args=(settings,))
+                p.start()
+
+        try:
+            start(
+                settings,
+                web=web,
+                extra_web_settings=extra_web_settings,
+                port=port,
+            )
+        except KeyboardInterrupt:
+            pass

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,110 @@
+import logging
+import typing as t
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock
+
+from saq.runner import run
+
+if t.TYPE_CHECKING:
+    from unittest.mock import MagicMock
+
+
+class TestRunner(unittest.TestCase):
+    def setUp(self):
+        self.settings = "settings"
+
+    @mock.patch("saq.runner.logging.basicConfig")
+    @mock.patch("saq.runner.start")
+    def test_runner_quiet_mode(self, start_mock: MagicMock, basic_config_mock: MagicMock) -> None:
+        run(self.settings, quiet=True)
+
+        basic_config_mock.assert_not_called()
+        start_mock.assert_called_once()
+
+    @mock.patch("saq.runner.logging.basicConfig")
+    @mock.patch("saq.runner.start")
+    def test_runner_logging_warning_level(
+        self, start_mock: MagicMock, basic_config_mock: MagicMock
+    ) -> None:
+        run(self.settings, quiet=False, verbose=0)
+
+        basic_config_mock.assert_called_once_with(level=logging.WARNING)
+        start_mock.assert_called_once()
+
+    @mock.patch("saq.runner.logging.basicConfig")
+    @mock.patch("saq.runner.start")
+    def test_runner_logging_info_level(
+        self, start_mock: MagicMock, basic_config_mock: MagicMock
+    ) -> None:
+        run(self.settings, quiet=False, verbose=1)
+
+        basic_config_mock.assert_called_once_with(level=logging.INFO)
+        start_mock.assert_called_once()
+
+    @mock.patch("saq.runner.logging.basicConfig")
+    @mock.patch("saq.runner.start")
+    def test_runner_logging_debug_level(
+        self, start_mock: MagicMock, basic_config_mock: MagicMock
+    ) -> None:
+        run(self.settings, quiet=False, verbose=2)
+
+        basic_config_mock.assert_called_once_with(level=logging.DEBUG)
+        start_mock.assert_called_once()
+
+    @mock.patch("saq.runner.sys.exit")
+    @mock.patch("saq.runner.check_health")
+    def test_runner_check_health(self, check_mock: MagicMock, sys_exit_mock) -> None:
+        run(
+            self.settings,
+            check=True,
+        )
+
+        check_mock.assert_called_once_with(self.settings)
+        sys_exit_mock.assert_called_once()
+
+    @mock.patch("saq.runner.start")
+    def test_runner_with_one_worker(self, start_mock: MagicMock) -> None:
+        run(
+            self.settings,
+            workers=1,
+        )
+
+        start_mock.assert_called_once_with(
+            self.settings,
+            web=False,
+            extra_web_settings=None,
+            port=8080,
+        )
+
+    @mock.patch("saq.runner.multiprocessing.Process")
+    @mock.patch("saq.runner.start")
+    def test_runner_with_multiple_workers(
+        self, start_mock: MagicMock, process_class_mock: MagicMock
+    ) -> None:
+        process = mock.MagicMock()
+        process_class_mock.return_value = process
+
+        run(
+            self.settings,
+            workers=2,
+        )
+
+        process_class_mock.assert_called_once_with(target=start_mock, args=(self.settings,))
+        process.start.assert_called_once()
+
+        start_mock.assert_called_once_with(
+            self.settings,
+            web=False,
+            extra_web_settings=None,
+            port=8080,
+        )
+
+    @mock.patch("saq.runner.start")
+    def test_runner_keyboard_interrupt_suppression(self, start_mock: MagicMock) -> None:
+        start_mock.side_effect = KeyboardInterrupt
+
+        try:
+            run(self.settings)
+        except KeyboardInterrupt:
+            self.fail("run() raised KeyboardInterrupt exception")


### PR DESCRIPTION
I wanted to run SAQ from the code, but faced an issue I need to modify sys.argv, because there are other arguments are passed that I can't modify.

This commit allows to run SAQ from the code directly not relying on args:

`saq.runner.run("path.to.settings")`

Also when I was refactoring I've noticed that port by default is None, but`saq.worker.start` accepts port as int only. It works, because `aiohttp.web.run_app` accepts port as `None`, but I mean it's better if we have everything strictly defined.