### PR TITLE
Record worker_id in job metadata once a job is picked up

### DIFF
--- a/saq/job.py
+++ b/saq/job.py
@@ -136,6 +136,7 @@ class Job:
     priority: int = 0
     group_key: str | None = None
     meta: dict[t.Any, t.Any] = dataclasses.field(default_factory=dict)
+    worker_id: str | None = None
 
     _EXCLUDE_NON_FULL = {
         "kwargs",

--- a/saq/worker.py
+++ b/saq/worker.py
@@ -307,6 +307,7 @@ class Worker:
 
             job.started = now()
             job.attempts += 1
+            job.worker_id = self.id
             await job.update(status=Status.ACTIVE)
             context = {**self.context, "job": job}
             await self._before_process(context)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -619,11 +619,11 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
     @mock.patch("saq.worker.logger")
     async def test_worker_id(self, _mock_logger: MagicMock) -> None:
         task = asyncio.create_task(self.worker.start())
-        job = await self.enqueue("sleeper",sleep=60)
+        job = await self.enqueue("sleeper", sleep=60)
         await asyncio.sleep(0.05)
         await job.refresh()
         self.assertEqual(job.status, Status.ACTIVE)
-        self.assertEqual(self.worker.id,job.worker_id)
+        self.assertEqual(self.worker.id, job.worker_id)
         task.cancel()
         await task
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -616,6 +616,17 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(job.status, Status.ABORTED)
         self.assertEqual(state["counter"], 1)
 
+    @mock.patch("saq.worker.logger")
+    async def test_worker_id(self, _mock_logger: MagicMock) -> None:
+        task = asyncio.create_task(self.worker.start())
+        job = await self.enqueue("sleeper",sleep=60)
+        await asyncio.sleep(0.05)
+        await job.refresh()
+        self.assertEqual(job.status, Status.ACTIVE)
+        self.assertEqual(self.worker.id,job.worker_id)
+        task.cancel()
+        await task
+
 
 class TestWorkerRedisQueue(TestWorker):
     async def asyncSetUp(self) -> None:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -620,7 +620,7 @@ class TestWorker(unittest.IsolatedAsyncioTestCase):
     async def test_worker_id(self, _mock_logger: MagicMock) -> None:
         task = asyncio.create_task(self.worker.start())
         job = await self.enqueue("sleeper", sleep=60)
-        await asyncio.sleep(0.05)
+        await asyncio.sleep(5)
         await job.refresh()
         self.assertEqual(job.status, Status.ACTIVE)
         self.assertEqual(self.worker.id, job.worker_id)


### PR DESCRIPTION
helps solving https://github.com/tobymao/saq/issues/258