### PR TITLE
fix: type context with generics

### DIFF
--- a/saq/types.py
+++ b/saq/types.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing as t
 from collections.abc import Collection
-from typing_extensions import Required, TypedDict
+from typing_extensions import Required, TypedDict, Generic
 
 if t.TYPE_CHECKING:
     from asyncio import Task
@@ -110,7 +110,10 @@ class PartialTimersDict(TimersDict, total=False):
     """
 
 
-class SettingsDict(TypedDict, total=False):
+CtxType = t.TypeVar("CtxType", bound=Context)
+
+
+class SettingsDict(TypedDict, Generic[CtxType], total=False):
     """
     Settings
     """
@@ -119,10 +122,10 @@ class SettingsDict(TypedDict, total=False):
     functions: Required[Collection[Function | tuple[str, Function]]]
     concurrency: int
     cron_jobs: Collection[CronJob]
-    startup: ReceivesContext
-    shutdown: ReceivesContext
-    before_process: ReceivesContext
-    after_process: ReceivesContext
+    startup: ReceivesContext[CtxType]
+    shutdown: ReceivesContext[CtxType]
+    before_process: ReceivesContext[CtxType]
+    after_process: ReceivesContext[CtxType]
     timers: PartialTimersDict
     dequeue_timeout: float
 
@@ -134,5 +137,5 @@ DurationKind = t.Literal["process", "start", "total", "running"]
 Function = t.Callable[..., t.Any]
 ListenCallback = t.Callable[[str, "Status"], t.Any]
 LoadType = t.Callable[[t.Union[bytes, str]], t.Any]
-ReceivesContext = t.Callable[[Context], t.Any]
+ReceivesContext = t.Callable[[CtxType], t.Any]
 VersionTuple = t.Tuple[int, ...]


### PR DESCRIPTION
Greetings, on the below snippet that hopefully is self-explnatory I got typing errors from pyright, which I solved  in this PR (caveat I'm no typing expert...).

The idea is the be able to use my own context type `MyContext` safely

```
import asyncio
import datetime
from functools import partial

import msgspec
from asyncpg import Pool, create_pool
from saq import CronJob, Queue
from saq.types import Context, SettingsDict

from damiers.config import Config


class MyContext(Context):
    pool: Pool


# all functions take in context dict and kwargs
async def test(ctx: MyContext, *, a:int) -> datetime.datetime:
    await asyncio.sleep(a/10)
    pool = ctx["pool"]
    async with pool.acquire() as cconnection:
        r = await cconnection.fetchval("select now()")
    return r


async def cron(ctx: MyContext):
    print("i am a cron job")
    pool = ctx["pool"]
    async with pool.acquire() as cconnection:
        r = await cconnection.fetch("select now()")
        print(r)


async def startup(ctx: MyContext, config: Config):
    asyncpg_pool = await create_pool(dsn=config.postgres.database_uri)
    ctx["pool"] = asyncpg_pool


async def shutdown(ctx: MyContext):
    pool = ctx["pool"]
    pool.terminate()
    await pool.close()


async def before_process(ctx: MyContext):
    print("i am a before process")
    print(ctx)


async def after_process(ctx: MyContext):
    print("after process hook called")
    print(ctx)


def saq_settings_factory() -> SettingsDict[MyContext]:
    config = Config()
    queue = Queue.from_url(
        config.redis.uri, dump=msgspec.json.encode, load=msgspec.json.decode
    )
    return SettingsDict(
        queue=queue,
        functions=[test],
        concurrency=100,
        cron_jobs=[CronJob(cron, cron="* * * * * */5")],
        startup=partial(startup, config=config),
        shutdown=shutdown,
        before_process=before_process,
        after_process=after_process,
    )
```
```
❯ basedpyright --level warning -w src/damiers/worker.py
/home/lotso/PycharmProjects/damiers/src/damiers/worker.py
  /home/lotso/PycharmProjects/damiers/src/damiers/worker.py:4:20 - warning: Import "Any" is not accessed (reportUnusedImport)
  /home/lotso/PycharmProjects/damiers/src/damiers/worker.py:23:9 - warning: Type of "r" is Any (reportAny)
  /home/lotso/PycharmProjects/damiers/src/damiers/worker.py:24:12 - warning: Return type is Any (reportAny)
  /home/lotso/PycharmProjects/damiers/src/damiers/worker.py:56:44 - error: Expected no type arguments for class "SettingsDict" (reportInvalidTypeArguments)
  /home/lotso/PycharmProjects/damiers/src/damiers/worker.py:66:17 - error: Argument of type "partial[CoroutineType[Any, Any, None]]" cannot be assigned to parameter "startup" of type "ReceivesContext" in function "__init__"
    Type "partial[CoroutineType[Any, Any, None]]" is not assignable to type "ReceivesContext"
      Parameter 1: type "Context" is incompatible with type "MyContext"
        "pool" is missing from "Context" (reportArgumentType)
  /home/lotso/PycharmProjects/damiers/src/damiers/worker.py:67:18 - error: Argument of type "(ctx: MyContext) -> CoroutineType[Any, Any, None]" cannot be assigned to parameter "shutdown" of type "ReceivesContext" in function "__init__"
    Type "(ctx: MyContext) -> CoroutineType[Any, Any, None]" is not assignable to type "ReceivesContext"
      Parameter 1: type "Context" is incompatible with type "MyContext"
        "pool" is missing from "Context" (reportArgumentType)
  /home/lotso/PycharmProjects/damiers/src/damiers/worker.py:68:24 - error: Argument of type "(ctx: MyContext) -> CoroutineType[Any, Any, None]" cannot be assigned to parameter "before_process" of type "ReceivesContext" in function "__init__"
    Type "(ctx: MyContext) -> CoroutineType[Any, Any, None]" is not assignable to type "ReceivesContext"
      Parameter 1: type "Context" is incompatible with type "MyContext"
        "pool" is missing from "Context" (reportArgumentType)
  /home/lotso/PycharmProjects/damiers/src/damiers/worker.py:69:23 - error: Argument of type "(ctx: MyContext) -> CoroutineType[Any, Any, None]" cannot be assigned to parameter "after_process" of type "ReceivesContext" in function "__init__"
    Type "(ctx: MyContext) -> CoroutineType[Any, Any, None]" is not assignable to type "ReceivesContext"
      Parameter 1: type "Context" is incompatible with type "MyContext"
        "pool" is missing from "Context" (reportArgumentType)
5 errors, 3 warnings, 0 notes
```

after PR:
```
❯ basedpyright --level warning -w src/damiers/worker.py
/home/lotso/PycharmProjects/damiers/src/damiers/worker.py
  /home/lotso/PycharmProjects/damiers/src/damiers/worker.py:4:20 - warning: Import "Any" is not accessed (reportUnusedImport)
  /home/lotso/PycharmProjects/damiers/src/damiers/worker.py:23:9 - warning: Type of "r" is Any (reportAny)
  /home/lotso/PycharmProjects/damiers/src/damiers/worker.py:24:12 - warning: Return type is Any (reportAny)
0 errors, 3 warnings, 0 notes
Watching for file changes...
```