### PR TITLE
Allow `redis` package version up to 6.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "hiredis": ["redis[hiredis]>=4.2.0"],
         "http": ["aiohttp"],
         "postgres": ["psycopg[pool]>=3.2.0"],
-        "redis": ["redis>=4.2,<6.0"],
+        "redis": ["redis>=4.2,<7.0"],
         "web": ["aiohttp", "aiohttp_basicauth"],
         "dev": [
             "aiohttp",
@@ -46,7 +46,7 @@ setup(
             "mypy",
             "psycopg[pool]>=3.2.0",
             "pre-commit",
-            "redis>=4.2,<6.0",
+            "redis>=4.2,<7.0",
             "ruff",
             "time-machine",
             "types-croniter",


### PR DESCRIPTION
Breaking changes and deprecations in 6.0.0 don't affect how SAQ uses the `redis` library, so we can allow its use.
Similarly the later available `redis` 6.x versions: 6.1.0, 6.1.1, 6.2.0, 6.3.0, 6.4.0 adhere to semantic versioning (double checked, because packages don't always follow semantic versioning) and don't have breaking changes nor deprecations.

`redis` 6.x supports Python 3.9+ similarly to SAQ. Python 3.8 support was dropped in `redis` v6.2.0.

Locally tests pass, except for 1 Postgres and 1 Redis test but those also fail on latest `main` for me.

References:
- https://github.com/redis/redis-py/releases/tag/v6.0.0
- https://github.com/redis/redis-py/tags