### PR TITLE
Allow redis-py 7.x (bump cap from <7.0 to <8.0)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "hiredis": ["redis[hiredis]>=4.2.0"],
         "http": ["aiohttp"],
         "postgres": ["psycopg[pool]>=3.2.0"],
-        "redis": ["redis>=4.2,<7.0"],
+        "redis": ["redis>=4.2,<8.0"],
         "web": ["aiohttp", "aiohttp_basicauth"],
         "dev": [
             "aiohttp",
@@ -47,7 +47,7 @@ setup(
             "pandas",
             "psycopg[pool]>=3.2.0",
             "pre-commit",
-            "redis>=4.2,<7.0",
+            "redis>=4.2,<8.0",
             "ruff",
             "time-machine",
             "types-croniter",


### PR DESCRIPTION
## Summary

Bump the `redis` dependency cap from `<7.0` to `<8.0` in both the `[redis]` extra and the `[dev]` extra, allowing projects to use redis-py 7.x with SAQ.

## Motivation

redis-py 7.0.0 was released October 2025 (latest: 7.4.0). The current `<7.0` cap blocks downstream projects from upgrading. The breaking changes in redis-py 7.x do not affect SAQ:

- **Type annotation improvements** — runtime behavior unchanged
- **Removed `parse_list_to_dict`** — not used by SAQ
- **`RLock` replacing `threading.Lock`** — internal to redis-py
- **Async `RedisCluster` context manager change** — SAQ doesn't use `RedisCluster`

SAQ's usage pattern (`redis.asyncio`, pipelines, `get`/`set`/`delete`/`eval`, pub/sub) is fully compatible with redis-py 7.x.

## Changes

- `setup.py`: `redis>=4.2,<7.0` → `redis>=4.2,<8.0` (2 occurrences)

Same analysis as the prior bump from `<6.0` to `<7.0` in commit cc8bef9.

Closes #291