### PR TITLE
fix(postgres): preserve group limits in batch dequeue

### DIFF
--- a/saq/queue/postgres.py
+++ b/saq/queue/postgres.py
@@ -646,7 +646,10 @@ class PostgresQueue(Queue):
                         dedent(
                             """
                             WITH eligible_jobs AS (
-                              SELECT DISTINCT ON (COALESCE(queued.group_key, queued.key))
+                              SELECT DISTINCT ON (
+                                queued.group_key IS NULL,
+                                COALESCE(queued.group_key, queued.key)
+                              )
                                 queued.key, queued.priority, queued.scheduled
                               FROM {jobs_table} AS queued
                               WHERE queued.status = 'queued'
@@ -664,6 +667,7 @@ class PostgresQueue(Queue):
                                   )
                                 )
                               ORDER BY
+                                queued.group_key IS NULL,
                                 COALESCE(queued.group_key, queued.key),
                                 queued.priority,
                                 queued.scheduled

--- a/saq/queue/postgres.py
+++ b/saq/queue/postgres.py
@@ -645,23 +645,36 @@ class PostgresQueue(Queue):
                     SQL(
                         dedent(
                             """
-                            WITH locked_job AS (
-                              SELECT key
-                              FROM {jobs_table}
-                              WHERE status = 'queued'
-                                AND queue = %(queue)s
+                            WITH eligible_jobs AS (
+                              SELECT DISTINCT ON (COALESCE(queued.group_key, queued.key))
+                                queued.key, queued.priority, queued.scheduled
+                              FROM {jobs_table} AS queued
+                              WHERE queued.status = 'queued'
+                                AND queued.queue = %(queue)s
                                 AND %(now)s >= scheduled
                                 AND priority BETWEEN %(plow)s AND %(phigh)s
-                                AND group_key NOT IN (
-                                  SELECT DISTINCT group_key
-                                  FROM {jobs_table}
-                                  WHERE status = 'active'
-                                    AND queue = %(queue)s
-                                    AND group_key IS NOT NULL
+                                AND (
+                                  queued.group_key IS NULL
+                                  OR NOT EXISTS (
+                                    SELECT 1
+                                    FROM {jobs_table} AS active
+                                    WHERE active.status = 'active'
+                                      AND active.queue = %(queue)s
+                                      AND active.group_key = queued.group_key
+                                  )
                                 )
-                              ORDER BY priority, scheduled
+                              ORDER BY
+                                COALESCE(queued.group_key, queued.key),
+                                queued.priority,
+                                queued.scheduled
+                            ),
+                            locked_job AS (
+                              SELECT queued.key
+                              FROM {jobs_table} AS queued
+                              JOIN eligible_jobs USING (key)
+                              ORDER BY queued.priority, queued.scheduled
                               LIMIT %(limit)s
-                              FOR UPDATE SKIP LOCKED
+                              FOR UPDATE OF queued SKIP LOCKED
                             )
                             UPDATE {jobs_table} SET status = 'active'
                             FROM locked_job

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -554,6 +554,23 @@ class TestPostgresQueue(TestQueue):
         self.assertEqual(await self.count("queued"), 0)
         self.assertEqual(await self.count("active"), 3)
 
+    async def test_schedule_activates_at_most_one_job_per_group(self) -> None:
+        self.queue._waiting = 10
+        await self.enqueue("test", group_key="shared")
+        await self.enqueue("test", group_key="shared")
+        await self.enqueue("test", group_key="independent")
+
+        await self.queue.schedule()
+
+        self.assertEqual(await self.count("active"), 2)
+        self.assertEqual(await self.count("queued"), 1)
+
+        await self.enqueue("test")
+        await self.queue.schedule()
+
+        self.assertEqual(await self.count("active"), 3)
+        self.assertEqual(await self.count("queued"), 1)
+
     async def test_enqueue_dup(self) -> None:
         job = await self.enqueue("test", key="1")
         self.assertEqual(job.id, "1")


### PR DESCRIPTION
## Summary

- preserve `group_key`'s one-active-job invariant when PostgreSQL dequeues a batch
- continue admitting ungrouped jobs while grouped jobs are active
- cover both cases with a scheduler regression test

## Root cause

The PostgreSQL dequeue query excluded groups that were already active before the
query, but it could select multiple queued rows from the same group within one
batch. Its `NOT IN` predicate also interacted with SQL `NULL` semantics so
ungrouped jobs were not eligible once any non-null group was active.

The candidate CTE now selects at most one queued job per non-null group, treats
each ungrouped job independently, and uses `NOT EXISTS` for the active-group
check.

## Validation

- `python -m unittest tests.test_queue.TestPostgresQueue.test_schedule_activates_at_most_one_job_per_group tests.test_queue.TestPostgresQueue.test_schedule tests.test_queue.TestPostgresQueue.test_group_key -v`
- `ruff check saq/queue/postgres.py tests/test_queue.py`
- `ruff format --check --line-length 100 --target-version py38 saq/queue/postgres.py tests/test_queue.py`
