### PR TITLE
Fix Queue.info(jobs=True) crashing on non-JSON-safe kwargs/result

### DIFF
--- a/saq/job.py
+++ b/saq/job.py
@@ -207,9 +207,16 @@ class Job:
     def abort_id(self) -> str:
         return f"{ABORT_ID_PREFIX}{self.key}"
 
-    def to_dict(self) -> dict[str, t.Any]:
+    def to_dict(self, safe: bool = False) -> dict[str, t.Any]:
         """
         Serialises the Job to dict
+
+        Args:
+            safe: If True, `kwargs`/`result` are converted to their repr() so the
+                dict is always JSON-serializable regardless of the queue's
+                `dump`/`load` (e.g. pickle-based queues carrying dates, UUIDs,
+                or other non-JSON-native payloads). Use for display/API purposes
+                only — never for round-trip (de)serialization.
         """
         result = {}
         for field in dataclasses.fields(self):
@@ -221,6 +228,8 @@ class Job:
                 continue
             if key == "queue" and value:
                 value = value.name
+            if safe and key in ("kwargs", "result"):
+                value = repr(value)
             result[key] = value
         return result
 

--- a/saq/queue/postgres.py
+++ b/saq/queue/postgres.py
@@ -288,7 +288,7 @@ class PostgresQueue(Queue):
                 )
                 rows = await cursor.fetchall()
             deserialized_jobs = (self.deserialize(*row) for row in rows)
-            jobs_info = [job.to_dict() for job in deserialized_jobs if job]
+            jobs_info = [job.to_dict(safe=True) for job in deserialized_jobs if job]
         else:
             jobs_info = []
 

--- a/saq/queue/redis.py
+++ b/saq/queue/redis.py
@@ -161,7 +161,9 @@ class RedisQueue(Queue):
             job_info = list(
                 {
                     job["key"]: job
-                    for job in (job.to_dict() for job in deserialized_jobs if job is not None)
+                    for job in (
+                        job.to_dict(safe=True) for job in deserialized_jobs if job is not None
+                    )
                 }.values()
             )
         else:

--- a/saq/web/common.py
+++ b/saq/web/common.py
@@ -30,9 +30,4 @@ def render(root_path: str) -> str:
 
 
 def job_dict(job: Job) -> dict:
-    data = job.to_dict()
-    if "kwargs" in data:
-        data["kwargs"] = repr(data["kwargs"])
-    if "result" in data:
-        data["result"] = repr(data["result"])
-    return data
+    return job.to_dict(safe=True)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import typing as t
 import unittest
+import uuid
 from unittest import mock
 
 from saq.job import Job, Status
@@ -152,6 +154,27 @@ class TestJob(unittest.IsolatedAsyncioTestCase):
 
         assert job.to_dict()["result"].equals(df)
         assert "result: Empty DataFrame" in job.info(True)
+
+    async def test_to_dict_safe(self) -> None:
+        # safe=False (default) is unaffected, and is what (de)serialization relies on
+        job = Job("f", key="a", kwargs={"x": uuid.uuid4()}, result=uuid.uuid4())
+        assert job.to_dict() == {
+            "function": "f",
+            "key": "a",
+            "kwargs": job.kwargs,
+            "result": job.result,
+        }
+
+        # safe=True reprs non-JSON-safe fields so the dict is always serializable
+        safe = job.to_dict(safe=True)
+        assert safe["kwargs"] == repr(job.kwargs)
+        assert safe["result"] == repr(job.result)
+        json.dumps(safe)
+
+        # Fields at their default are still omitted entirely, safe or not
+        job = Job("f", key="a")
+        assert "kwargs" not in job.to_dict(safe=True)
+        assert "result" not in job.to_dict(safe=True)
 
 
 class TestJobRedisQueue(TestJob):

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import pickle
 import time
 import typing as t
 import unittest
+import uuid
 from functools import partial
 from unittest import mock
 
@@ -257,6 +259,18 @@ class TestQueue(unittest.IsolatedAsyncioTestCase):
         await worker.queue.sweep()
         info = await self.queue.info(jobs=True)
         self.assertEqual(info["workers"], {})
+
+    async def test_info_jobs_json_safe(self) -> None:
+        # Queues that pickle payloads can carry kwargs/results that aren't JSON-native
+        # (dates, UUIDs, etc). info(jobs=True) must still produce a JSON-serializable
+        # payload, mirroring the safety conversion applied to the single-job route.
+        self.queue = await self.create_queue(dump=pickle.dumps, load=pickle.loads)
+        await self.enqueue("echo", a=uuid.uuid4())
+
+        info = await self.queue.info(jobs=True)
+        self.assertEqual(len(info["jobs"]), 1)
+        json.dumps(info)  # must not raise TypeError
+        self.assertIsInstance(info["jobs"][0]["kwargs"], str)
 
     @mock.patch("saq.utils.time")
     async def test_schedule(self, mock_time: MagicMock) -> None:


### PR DESCRIPTION
## Summary

`RedisQueue.info(jobs=True)` and `PostgresQueue.info(jobs=True)` return the job list as raw `Job.to_dict()` entries. Unlike the single-job web route (`saq.web.common.job_dict()`), which already `repr()`s `kwargs`/`result` before returning them, the queue-overview list did not apply that same conversion.

For any queue configured with a non-JSON `dump`/`load` (e.g. `pickle.dumps`/`pickle.loads`, needed when job kwargs carry dates, UUIDs, or other non-JSON-native objects), calling `info(jobs=True)` on a queue with an active/queued job produces a payload that crashes `JSONResponse`/`json.dumps` with an unhandled `TypeError`. In practice this breaks the SAQ dashboard's queue-overview endpoint (`/api/queues/{queue}`) for any pickle-based queue, even though drilling into a single job works fine.

## Fix

- `saq/job.py`: `Job.to_dict()` gains an opt-in `safe: bool = False` parameter that `repr()`s `kwargs`/`result` when set. Default behavior (used for actual job (de)serialization) is unchanged.
- `saq/web/common.py`: `job_dict()` now delegates to `job.to_dict(safe=True)` instead of duplicating the repr logic.
- `saq/queue/redis.py` / `saq/queue/postgres.py`: `info(jobs=True)` now builds job dicts with `safe=True`, so the queue-overview payload is always JSON-serializable.
- `saq/queue/http.py` needs no change — it proxies to the real backend's `.info()`, which already gets the fix.

## Tests

- `tests/test_job.py::test_to_dict_safe` — covers `to_dict(safe=True)` reprs `kwargs`/`result`, `safe=False` is unaffected, and fields at their default are still omitted.
- `tests/test_queue.py::test_info_jobs_json_safe` (runs against both Redis and Postgres via the shared `TestQueue` base) — enqueues a job with a non-JSON-safe kwarg on a pickle-based queue and asserts `info(jobs=True)` is `json.dumps`-able. Verified this test reproduces the exact `TypeError: Object of type UUID is not JSON serializable` crash when the fix is reverted.

## Test plan

- [x] `python -m unittest tests.test_job -v` — all pass (Redis + Postgres)
- [x] `python -m unittest tests.test_queue.TestRedisQueue.test_info_jobs_json_safe tests.test_queue.TestPostgresQueue.test_info_jobs_json_safe -v` — pass
- [x] Full suite (`coverage run -m unittest`) — 283/284 pass; the one failure (`TestHttpRedis.test_cron`) is a pre-existing flaky timing test, reproduced independently on unmodified `main`
- [x] `ruff check` / `ruff format --line-length 100` / `mypy saq` — no new issues versus baseline